### PR TITLE
Define BGZF EOF marker in SAM/BAM specification

### DIFF
--- a/SAMv1.tex
+++ b/SAMv1.tex
@@ -770,7 +770,10 @@ All BGZF files (including BAM files) should by convention finish with
 a specific empty BGZF block, encoded with default compression,
 which serves as a 28 byte end-of-file (EOF) marker. In hex this is
 \texttt{"1f 8b 08 04 00 00 00 00 00 ff 06 00 42 43 02 00 1b 00 03 00 00 00 00 00 00 00 00 00"}.
-The absence of this EOF marker should trigger a warning or error.
+The absence of this EOF marker should trigger a warning or error
+when opening a BGZF file where random access is available.
+When reading a streamed BGZF file, ideally this EOF check should
+be performed when the end of the stream is reached.
 
 \subsection{The BAM format}
 BAM is compressed in the BGZF format. All multi-byte numbers in BAM are


### PR DESCRIPTION
This has repeatedly come up on the samtools-devel mailing lists, especially by developers of new BAM implementations, and needs to be in the specification.
