### PR TITLE
fix type, table descibes a BGZF *block*, not a file.

### DIFF
--- a/SAMv1.tex
+++ b/SAMv1.tex
@@ -724,7 +724,7 @@ standard-compliant extensions:
   BGZF block minus one.
 \end{enumerate}
 
-On disk, a full BGZF file is (all integers are little endian as is
+On disk, a full BGZF block is (all integers are little endian as is
 required by RFC1952):
 \begin{table}[ht]
 \centering


### PR DESCRIPTION
This got me confused for a bit. The table does in theory describe a full file, but more properly, a full block!
