### PR TITLE
Add n_no_coor to index formats 

### DIFF
--- a/CSIv1.tex
+++ b/CSIv1.tex
@@ -33,7 +33,8 @@
   & & \multicolumn{2}{l|}{\sf n\_chunk} & \# chunks & {\tt int32\_t} & \\\cline{3-7}
   & & \multicolumn{5}{c|}{\textcolor{gray}{\it List of chunks (n=n\_chunk)}} \\\cline{4-7}
   & & & {\sf chunk\_beg} & (Virtual) file offset of the start of the chunk & {\tt uint64\_t} & \\\cline{4-7}
-  & & & {\sf chunk\_end} & (Virtual) file offset of the end of the chunk & {\tt uint64\_t} & \\\cline{2-7}
+  & & & {\sf chunk\_end} & (Virtual) file offset of the end of the chunk & {\tt uint64\_t} & \\\cline{1-7}
+  \multicolumn{4}{|l|}{\sf n\_no\_coor} & (Optional) \# unmapped unplaced reads ({\sf RNAME} *) & {\tt uint64\_t} & \\
   \cline{1-7}
 \end{tabular}}
 \end{table}

--- a/SAMv1.tex
+++ b/SAMv1.tex
@@ -925,7 +925,8 @@ saved.
   & & & {\sf chunk\_end} & (Virtual) file offset of the end of the chunk & {\tt uint64\_t} & \\\cline{2-7}
   & \multicolumn{3}{l|}{\sf n\_intv} & \# 16kbp intervals (for the linear index) & {\tt int32\_t} & \\\cline{2-7}
   & \multicolumn{6}{c|}{\textcolor{gray}{\it List of intervals (n=n\_intv)}} \\\cline{3-7}
-  & & \multicolumn{2}{l|}{\sf ioffset} & (Virtual) file offset of the first alignment in the interval & {\tt uint64\_t} & \\
+  & & \multicolumn{2}{l|}{\sf ioffset} & (Virtual) file offset of the first alignment in the interval & {\tt uint64\_t} & \\\cline{1-7}
+  \multicolumn{4}{|l|}{\sf n\_no\_coor} & (Optional) \# unmapped unplaced reads ({\sf RNAME} *) & {\tt uint64\_t} & \\
   \cline{1-7}
 \end{tabular}}
 \end{table}

--- a/tabix.tex
+++ b/tabix.tex
@@ -61,7 +61,8 @@
 \cline{2-7}
  & \multicolumn{6}{c|}{\textcolor{gray}{\it List of distinct intervals (n=n\_intv)}} \\
 \cline{3-7}
- & & \multicolumn{2}{l|}{\tt ioff} & File offset of the first record in the interval & {\tt uint64\_t} & \\
+ & & \multicolumn{2}{l|}{\tt ioff} & File offset of the first record in the interval & {\tt uint64\_t} & \\\cline{1-7}
+\multicolumn{4}{|l|}{\sf n\_no\_coor} & \# unmapped reads without coordinates set & {\tt uint64\_t} & \\
 \hline
 \end{tabular}
 \end{center}


### PR DESCRIPTION
This change appends the n_no_coor fields to index formats given that it appears to have been being written by samtools there for a few years.
