### PR TITLE
Remove SAM's artificial 'i' optional field range limit

### DIFF
--- a/SAMv1.tex
+++ b/SAMv1.tex
@@ -392,13 +392,19 @@ defines the format of {\tt VALUE}:
 {\bf Type} & {\bf Regexp matching {\tt VALUE}} & {\bf Description} \\
 \hline
 A & {\tt [!-\char126]} & Printable character \\
-i & {\tt [-+]?[0-9]+} & Singed 32-bit integer \\
+i & {\tt [-+]?[0-9]+} & Signed integer\footnotemark\\
 f & {\tt [-+]?[0-9]*\char92.?[0-9]+([eE][-+]?[0-9]+)?} & Single-precision floating number \\
 Z & {\tt [\,\,\,!-\char126]+} & Printable string, including space\\
 H & {\tt [0-9A-F]+} & Byte array in the Hex format\footnotemark\\
 B & {\tt [cCsSiIf](,[-+]?[0-9]*\char92.?[0-9]+([eE][-+]?[0-9]+)?)+} & Integer or numeric array\\
 \hline
 \end{tabular}
+\addtocounter{footnote}{-1}
+\footnotetext{The number of digits in an integer optional field is not
+explicitly limited in SAM.  However, BAM can represent values in the
+range~$[-2^{31},2^{32})$, so in practice this is the realistic range
+of values for SAM's `{\tt i}' as well.}
+\stepcounter{footnote}
 \footnotetext{For example, a byte array {\tt \{0x1a,0xe3,0x1\}} corresponds to a Hex string `{\tt 1AE301}'.}
 \end{center}
 For an integer or numeric array (type `{\tt B}'), the first letter indicates the type of numbers
@@ -873,7 +879,8 @@ is $4680$.}
 \footnotetext{For backward compatibility, a {\sf QNAME} `{\tt *}' is stored as a C string {\tt "*\char92 0"}.}
 \stepcounter{footnote}
 \footnotetext{An integer may be stored as one of `{\tt cCsSiI}' in BAM, representing {\tt int8\_t}, {\tt uint8\_t},
-	{\tt int16\_t}, {\tt uint16\_t}, {\tt int32\_t} and {\tt uint32\_t}, respectively. In SAM, all single integer types are mapped to {\tt int32\_t}.}
+{\tt int16\_t}, {\tt uint16\_t}, {\tt int32\_t} and {\tt uint32\_t}, respectively.
+In SAM, all single (i.e., non-array) integer types are stored as `{\tt i}', regardless of magnitude.}
 \stepcounter{footnote}
 \footnotetext{A `{\tt B}'-typed (array) tag--value pair is stored as follows. The first two bytes keep the two-character tag. The 3rd byte is always `{\tt B}'.
 	The 4th byte, matching {\tt /\char94[cCsSiIf]\$/}, indicates the type of an element in the array.


### PR DESCRIPTION
See motivation in #36 and [several samtools#304 comments](https://github.com/samtools/samtools/issues/304#issuecomment-57438913): in short, SAM should be able to represent everything that BAM can represent.

The footnote text at line 860ff originally (see ec8fe9550700fc1d727de52e277faebf4d2e59fc) said

> An integer may be stored [in BAM] as `cCsSiI` depending on the magnitude of the integer. In SAM, all integer types are mapped to `i`.

It was later changed in 598d0141b6cab13afd1f51dc6cf98b815a49827c ("[...] Added BAM tag type "B"; Other format changes and minor clarifications") and ceaff87e7afaef8b754fd6d7ae9354c5a45d2e27 ("Added the B type"; addition of "single") to

> An integer may be stored as one of `cCsSiI` in BAM, representing `int8_t`, `uint8_t`, `int16_t`, `uint16_t`, `int32_t` and `uint32_t`, respectively. In SAM, all single integer types are mapped to `int32_t`.

It seems to me that the SAM sentence's change from `i` to `int32_t` comes under the commit message's category of "minor clarifications" and so the restriction on the range of SAM integers created here is unintended.  So this PR returns the footnote to a clarified version of the original text.

Unfortunately the table in §1.5 has always said that a SAM `i` field is a **32-bit** integer.  IMHO this is not a particularly meaningful thing to say of a textual item, and it seems to me that this has always been a mistake.  So the proposal is to delete this and just describe SAM `i` fields as textual strings of digits, potentially without limit but practically limited by concerns about interchange with the BAM representation.

@tfenne: are you happy with this?  For Java versions with 32-bit signed `int` that don't believe in unsigned, this might cause some implementation difficulties -- but presumably no worse than any difficulties that BAM's `uint32_t` `I` field already causes.