### PR TITLE
Fix typo in Genotype encoding example

### DIFF
--- a/VCFv4.2.tex
+++ b/VCFv4.2.tex
@@ -1104,7 +1104,7 @@ Genotype fields are encoded not by sample as in VCF but rather by field, with a 
 \vspace{0.3cm}
 \begin{tabular}{l l l l}
 FORMAT & NA00001 & NA00002 & NA00003 \\
-GT:GQ:DP & 0/0:48:1 & 0/1:48:8 & 1/1:43:5 \\
+GT:GQ:DP & 0/0:48:1 & 0/1:9:8 & 1/1:43:5 \\
 \end{tabular}
 \vspace{0.3cm}
 


### PR DESCRIPTION
The NA00002 GQ in the VCF line does not match the encoded equivalent.