### PR TITLE
Collected header additions: HD-GO, RG-PL:ONT, and RG-PM

### DIFF
--- a/SAMv1.tex
+++ b/SAMv1.tex
@@ -172,6 +172,11 @@ The following table give the defined record types and tags. Tags with
   minor sort key is the {\sf POS} field.  For alignments with equal {\sf RNAME} and {\sf POS}, order is
   arbitrary.  All alignments with `{\tt *}' in {\sf RNAME} field follow alignments with some other
   value but otherwise are in arbitrary order.\\\cline{1-3}
+  & {\tt GO} & Grouping of alignments, indicating that similar alignment records
+    are grouped together but the file is not necessarily sorted overall.
+    \emph{Valid values}: {\tt none} (default), {\tt query} (alignments are
+    grouped by {\sf QNAME}), and {\tt reference} (alignments are grouped by
+    {\sf RNAME}/{\sf POS}).\\\cline{1-3}
   \multicolumn{2}{|l}{\tt @SQ} & Reference sequence dictionary. The order of {\tt @SQ} lines defines the alignment sorting order.\\\cline{2-3}
   & {\tt SN}* & Reference sequence name. Each {\tt @SQ} line must have a unique {\tt SN} tag. The value of this
   field is used in the
@@ -195,7 +200,9 @@ The following table give the defined record types and tags. Tags with
   & {\tt PG} & Programs used for processing the read group.\\\cline{2-3}
   & {\tt PI} & Predicted median insert size.\\\cline{2-3}
   & {\tt PL} & Platform/technology used to produce the reads. \emph{Valid values}:
-  {\tt CAPILLARY}, {\tt LS454}, {\tt ILLUMINA}, {\tt SOLID}, {\tt HELICOS}, {\tt IONTORRENT} and {\tt PACBIO}.\\\cline{2-3}
+  {\tt CAPILLARY}, {\tt LS454}, {\tt ILLUMINA}, {\tt SOLID}, {\tt HELICOS}, {\tt IONTORRENT}, {\tt ONT}, and {\tt PACBIO}.\\\cline{2-3}
+  & {\tt PM} & Platform model. Free-form text providing further details of the
+  platform/technology used.\\\cline{2-3}
   & {\tt PU} & Platform unit (e.g. flowcell-barcode.lane for Illumina or slide for SOLiD). Unique identifier.\\\cline{2-3}
   & {\tt SM} & Sample. Use pool name where a pool is being sequenced.\\\cline{1-3}
   \multicolumn{2}{|l}{\tt @PG} & Program. \\\cline{2-3}
@@ -544,7 +551,8 @@ specific software package for it to function properly.
 \begin{enumerate}
 \item The header section
   \begin{enumerate}[label=\arabic*]
-  \item The {\tt @HD} line should be present with the {\tt SO} tag specified.
+  \item The {\tt @HD} line should be present, with either the {\tt SO} tag
+    or the {\tt GO} tag (but not both) specified.
   \item The {\tt @SQ} lines should be present if reads have been mapped.
   \item When a {\tt RG} tag appears anywhere in the alignment section,
     there should be a single corresponding {\tt @RG} line with matching


### PR DESCRIPTION
1. Reinstate the previously-specified `@HD-GO` tag.  See #15.  The text in the pre-TeX specification was

    > **GO**  Group order (full sorting is not imposed in a group). Valid values: none (default), query, and reference.

    It would be possible to require that if both `SO` and `GO` are specified then they must agree with each other (e.g. `SO:queryname GO:query`), but it seems easier to discourage specifying both together.  (Also perhaps we could have a footnote noting that `GO:reference` is fairly pointless!)

2. Add `ONT` (Oxford Nanopore) as a valid value for `@RG-PL`.  See #39.

3. Add new free-form `@RG-PM` tag to allow more details about the platform to be given, e.g., machine models such as 'HiSeq 2500'.  See #16.

These additions mangle the formatting of the header table, but I propose to tidy that up later when some of the information in the table moves to a new `SAMtags.pdf` (filename tbd) document.