### PR TITLE
implementation of https://github.com/samtools/hts-specs/issues/100

### DIFF
--- a/SAMv1.tex
+++ b/SAMv1.tex
@@ -200,7 +200,7 @@ meanings can be avoided.}
   & {\tt AS} & Genome assembly identifier. \\\cline{2-3}
   & {\tt M5} & MD5 checksum of the sequence in the uppercase, excluding spaces but including pads (as `*'s).\\\cline{2-3}
   & {\tt SP} & Species.\\\cline{2-3}
-  & {\tt AN} & Reference sequence Aternative Names. A semicolon separated list of alternative names for this sequence e.g: {\tt 1;01;CM000663;NC\_000001.10}. Tools are free to use this information to decode the users' positions but the name displayed in the output is always {\tt SN}.\\\cline{2-3}
+  & {\tt AN} & Reference sequence Alternative Names. A semicolon separated list of alternative names for this sequence e.g: {\tt 1;01;CM000663;NC\_000001.10}. Tools are free to use this information to decode the users' positions but the name displayed in the output is always {\tt SN}.\\\cline{2-3}
   & {\tt UR} & URI of the sequence.  This value may start with one of the standard
   protocols, e.g http: or ftp:.  If it does not start with one of these protocols, it is assumed to be a file-system path.\\\cline{1-3}
   \multicolumn{2}{|l}{\tt @RG} & Read group. Unordered multiple {\tt @RG} lines are allowed.\\\cline{2-3}

--- a/SAMv1.tex
+++ b/SAMv1.tex
@@ -200,6 +200,7 @@ meanings can be avoided.}
   & {\tt AS} & Genome assembly identifier. \\\cline{2-3}
   & {\tt M5} & MD5 checksum of the sequence in the uppercase, excluding spaces but including pads (as `*'s).\\\cline{2-3}
   & {\tt SP} & Species.\\\cline{2-3}
+  & {\tt AN} & Reference sequence Aternative Names. A semicolon separated list of alternative names for this sequence e.g: {\tt 1;01;CM000663;NC\_000001.10}. Tools are free to use this information to decode the users' positions but the name displayed in the output is always {\tt SN}.\\\cline{2-3}
   & {\tt UR} & URI of the sequence.  This value may start with one of the standard
   protocols, e.g http: or ftp:.  If it does not start with one of these protocols, it is assumed to be a file-system path.\\\cline{1-3}
   \multicolumn{2}{|l}{\tt @RG} & Read group. Unordered multiple {\tt @RG} lines are allowed.\\\cline{2-3}


### PR DESCRIPTION
Hi , this is a pull request to suggest a new Tag **AN**  for **@SEQ** in the sequence dictionary.

> Reference sequence Aternative Names. A semicolon separated list of alternative names for this sequence e.g:
> 1;01;CM000663;NC 000001.10. Tools are free to use this information to decode the users’ posi-
> tions.

see also issue id 100: https://github.com/samtools/hts-specs/issues/100
