### PR TITLE
VCF INFO and SAMPLE reserved fields

### DIFF
--- a/VCFv4.3.tex
+++ b/VCFv4.3.tex
@@ -344,7 +344,7 @@ There are 8 fixed fields per record.  Fixed fields are:
 	AF		& A		& Float		& Allele frequency for each ALT allele in the same order as listed (use this when estimated from primary data, not called genotypes) \\
 	AN		& 1		& Integer	& Total number of alleles in called genotypes \\
 	BQ   		& 1		& Float		& RMS base quality \\
-	CIGAR		& 1		& String	& Cigar string describing how to align an alternate allele to the reference allele \\
+	CIGAR		& A		& String	& Cigar string describing how to align an alternate allele to the reference allele \\
 	DB		& 0		& Flag		& dbSNP membership \\
 	DP		& 1		& Integer	& Combined depth across samples \\
 	END		& 1		& Integer	& End position (for use with symbolic alleles) \\
@@ -362,8 +362,10 @@ There are 8 fixed fields per record.  Fixed fields are:
     \label{table:reserved-info}
   \end{table}
   
-The exact format of each INFO sub-field should be specified in the meta-information (as described above).
-Example for an INFO field: DP=154;MQ=52;H2. Keys without corresponding values are allowed in order to indicate group membership (e.g. H2 indicates the SNP is found in HapMap 2). It is not necessary to list all the properties that a site does NOT have, by e.g. H2=0. See Section~\ref{sv-info-keys} for additional reserved INFO sub-fields used to encode structural variants.
+  The exact format of each INFO sub-field should be specified in the meta-information (as described above).
+  Example for an INFO field: DP=154;MQ=52;H2. Keys without corresponding values are allowed in order to indicate group membership (e.g. H2 indicates the SNP is found in HapMap 2). It is not necessary to list all the properties that a site does NOT have, by e.g. H2=0. See Section~\ref{sv-info-keys} for additional reserved INFO sub-fields used to encode structural variants.
+\end{enumerate}
+  
 \subsubsection{Genotype fields}
 If genotype information is present, then the same types of data must be present
 for all samples. First a FORMAT field is given specifying the data types and

--- a/VCFv4.3.tex
+++ b/VCFv4.3.tex
@@ -390,8 +390,8 @@ See table~\ref{table:reserved-genotypes} for a list of common, reserved keywords
       HQ		& 2		& Integer	& Haplotype (phred) qualities \\
       MQ		& 1		& Integer	& RMS mapping quality \\
       PL		& G		& Integer	& Phred-scaled genotype likelihoods rounded to the closest integer (and otherwise defined precisely as the GL field) \\
-      PQ		& ?		& Integer	& Phasing quality, the phred-scaled probability that alleles are ordered incorrectly in a heterozygote (against all other members in the phase set). More details in Subsection~\ref{para:genotype-PQ} \\
-      PS		& ?		& Integer (non-negative)	& Phase set, set of phased genotypes to which this genotype belongs \\
+      PQ		& 1		& Integer	& Phasing quality, the phred-scaled probability that alleles are ordered incorrectly in a heterozygote (against all other members in the phase set). More details in Subsection~\ref{para:genotype-PQ} \\
+      PS		& 1		& Integer (non-negative)	& Phase set, set of phased genotypes to which this genotype belongs \\
   \end{tabularx}
   \caption{Reserved genotype fields}
   \label{table:reserved-genotypes}

--- a/VCFv4.3.tex
+++ b/VCFv4.3.tex
@@ -385,7 +385,7 @@ See table~\ref{table:reserved-genotypes} for a list of common, reserved keywords
       FT		& 1		& String	& Filter indicating if this genotype was ``called''. More details in Subsection~\ref{para:genotype-FT} \\
       GL		& G		& Float		& $log_{10}$-scaled likelihoods for all possible genotypes given the set of alleles defined in the REF and ALT fields. More details in Subsection~\ref{para:genotype-GL} \\
       GP		& G		& Float		& Genotype posterior probabilities in the range 0 to 1 using the same ordering as the GL field (could be used to store imputed genotype probabilities) \\
-      GQ		& 1		& Float		& Conditional genotype quality, encoded as a phred quality $-10log_{10}$ p(genotype call is wrong, conditioned on the site's being variant) \\
+      GQ		& 1		& Integer	& Conditional genotype quality, encoded as a phred quality $-10log_{10}$ p(genotype call is wrong, conditioned on the site's being variant) \\
       GT   		& 1		& Integer	& Genotype, encoded as allele values separated by either of $/$ or $\mid$. \\
       HQ		& 2		& Integer	& Haplotype (phred) qualities \\
       MQ		& 1		& Integer	& RMS mapping quality \\

--- a/VCFv4.3.tex
+++ b/VCFv4.3.tex
@@ -367,99 +367,107 @@ There are 8 fixed fields per record.  Fixed fields are:
 \end{enumerate}
   
 \subsubsection{Genotype fields}
-If genotype information is present, then the same types of data must be present
-for all samples. First a FORMAT field is given specifying the data types and
-order (colon-separated FORMAT ids matching the regular expression \texttt{\^{}[A-Za-z\_][0-9A-Za-z\_.]*\$}, duplicate fields are not allowed). This is followed by one data block per
-sample, with the colon-separated data corresponding to the types
-specified in the format. The first sub-field must always be the genotype (GT)
-if it is present.  There are no required sub-fields.
+If genotype information is present, then the same types of data must be present for all samples. First a FORMAT field is given specifying the data types and order (colon-separated FORMAT ids matching the regular expression \texttt{\^{}[A-Za-z\_][0-9A-Za-z\_.]*\$}, duplicate fields are not allowed). This is followed by one data block per sample, with the colon-separated data corresponding to the types specified in the format. The first sub-field must always be the genotype (GT) if it is present. There are no required sub-fields. Additional Genotype fields can be defined in the meta-information, however, software support for such fields is not guaranteed.
 
-As with the INFO field, there are several common, reserved keywords that are standards across the community:
+If any of the fields is missing, it is replaced with the missing value. For example if the FORMAT is GT:GQ:DP:HQ then $0\mid0:.:23:23,34$ indicates that GQ is missing. Trailing fields can be dropped, with the exception of the GT field, which should always be present if specified in the FORMAT field.
 
+See table~\ref{table:reserved-genotypes} for a list of common, reserved keywords that are standards across the community, and the following points for detailed explanations about the most complex among them. See also Section~\ref{sv-format-keys} for a list of genotype keys reserved for structural variants.
+
+\begin{table}[htbp]
+  \centering
+  \begin{tabularx}{\textwidth}{ | l | l | l | X | }
+      Field		& Number	& Type		& Description \\ \hline
+      AD		& R		& Integer	& Per-sample read depth for each allele \\
+      ADF		& R		& Integer	& Per-sample read depth for each allele on the forward strand \\
+      ADR		& R		& Integer	& Per-sample read depth for each allele on the reverse strand \\
+      DP		& 1		& Integer	& Per-sample read depth \\
+      EC		& A		& Integer	& Expected alternate allele counts for each alternate allele, in the same order as listed in the ALT field (typically used in association analyses) \\
+      FT		& 1		& String	& Filter indicating if this genotype was ``called''. More details in Subsection~\ref{para:genotype-FT} \\
+      GL		& G		& Float		& $log_{10}$-scaled likelihoods for all possible genotypes given the set of alleles defined in the REF and ALT fields. More details in Subsection~\ref{para:genotype-GL} \\
+      GP		& G		& Float		& Genotype posterior probabilities in the range 0 to 1 using the same ordering as the GL field (could be used to store imputed genotype probabilities) \\
+      GQ		& 1		& Float		& Conditional genotype quality, encoded as a phred quality $-10log_{10}$ p(genotype call is wrong, conditioned on the site's being variant) \\
+      GT   		& 1		& Integer	& Genotype, encoded as allele values separated by either of $/$ or $\mid$. \\
+      HQ		& 2		& Integer	& Haplotype (phred) qualities \\
+      MQ		& 1		& Integer	& RMS mapping quality \\
+      PL		& G		& Integer	& Phred-scaled genotype likelihoods rounded to the closest integer (and otherwise defined precisely as the GL field) \\
+      PQ		& ?		& Integer	& Phasing quality, the phred-scaled probability that alleles are ordered incorrectly in a heterozygote (against all other members in the phase set). More details in Subsection~\ref{para:genotype-PQ} \\
+      PS		& ?		& Integer (non-negative)	& Phase set, set of phased genotypes to which this genotype belongs \\
+  \end{tabularx}
+  \caption{Reserved genotype fields}
+  \label{table:reserved-genotypes}
+\end{table}
+  
+\paragraph{FT subfield} \label{para:genotype-FT}
+Sample genotype filter indicating if this genotype was ``called'' (similar in concept to the FILTER field). Again, use PASS to indicate that all filters have been passed, a semi-colon separated list of codes for filters that fail, or `.' to indicate that filters have not been applied. No white-space or semi-colons are permitted in a filter name. These values should be described in the meta-information in the same way as FILTERs.
+
+\paragraph{GL subfield} \label{para:genotype-GL}
+Genotype likelihoods comprised of comma separated floating point $log_{10}$-scaled likelihoods for all possible genotypes given the set of alleles defined in the REF and ALT fields. In presence of the GT field the same ploidy is expected; without GT field, diploidy is assumed. 
+
+\textsc{Genotype Ordering.} In general case of ploidy P and N alternate alleles (0 is the REF and 1..N the alternate alleles), the ordering of genotypes for the likelihoods can be expressed by the following pseudocode with as many nested loops as ploidy:\footnote{Note that we use inclusive \texttt{for} loop boundaries.}
+\begingroup
+\small
+\begin{lstlisting}
+for $a_P = 0\ldots N$
+  for $a_{P-1} = 0\ldots a_P$
+      $\ldots$
+      for $a_1 = 0\ldots a_{2}$
+	  println $a_1 a_2  \ldots  a_P$
+\end{lstlisting}
+\endgroup
+
+Alternatively, the same can be achieved recursively with the following pseudocode:
+\begingroup
+\small
+\begin{lstlisting}
+  Ordering($P$, $N$, suffix=""):
+      for $a$ in $0\ldots N$
+	  if ($P == 1$) println str($a$) + suffix
+	  if ($P > 1$) Ordering($P$-1, $a$, str($a$) + suffix)
+\end{lstlisting}
+\endgroup
+
+Conversely, the index of the value corresponding to the genotype $k_1\le k_2\le\ldots\le k_P$ is
+\begingroup
+\small
+\begin{lstlisting}
+  Index($k_1/k_2/\ldots/k_P$) = $\sum_{m=1}^{P} {k_m + m - 1 \choose m}$
+\end{lstlisting}
+\endgroup
+
+Examples:
 \begin{itemize}
-\renewcommand{\labelitemii}{$\circ$}
-  \item AD, ADF, ADR: per-sample read depths for each allele; total (AD), on the forward (ADF) and the reverse (ADR) strand (Integer, Number=R)
-  \item DP : read depth at this position for this sample (Integer)
-  \item EC : comma separated list of expected alternate allele counts for each alternate allele in the same order as listed in the ALT field (typically used in association analyses) (Integers)
-  \item FT : sample genotype filter indicating if this genotype was ``called'' (similar in concept to the FILTER field). Again, use PASS to indicate that all filters have been passed, a semi-colon separated list of codes for filters that fail, or `.' to indicate that filters have not been applied. These values should be described in the meta-information in the same way as FILTERs (String, no white-space or semi-colons permitted)
-  \item GQ : conditional genotype quality, encoded as a phred quality $-10log_{10}$ p(genotype call is wrong, conditioned on the site's being variant) (Integer)
-  \item GP : genotype posterior probabilities in the range 0 to 1 using the same ordering as the GL field; one use can be to store imputed genotype probabilities (Float)
-  \item GT : genotype, encoded as allele values separated by either of $/$ or $\mid$. The allele values are 0 for the reference allele (what is in the REF field), 1 for the first allele listed in ALT, 2 for the second allele list in ALT and so on. For diploid calls examples could be $0/1$, $1\mid0$, or $1/2$, etc. For haploid calls, e.g. on Y, male non-pseudoautosomal X, or mitochondrion, only one allele value should be given; a triploid call might look like $0/0/1$. If a call cannot be made for a sample at a given locus, `.' should be specified for each missing allele in the GT field (for example `$./.$' for a diploid genotype and `.' for haploid genotype). The meanings of the separators are as follows (see the PS field below for more details on incorporating phasing information into the genotypes):
-	\begin{itemize}
-	  \item $/$ : genotype unphased
-	  \item $\mid$ : genotype phased
-	\end{itemize}
-
-  \item GL : genotype likelihoods comprised of comma separated floating point
-  $log_{10}$-scaled likelihoods for all possible genotypes given the set of
-  alleles defined in the REF and ALT fields. In presence of the GT field the
-  same ploidy is expected; without GT field, diploidy is assumed. 
-
-  \textsc{Genotype Ordering.} In general case of ploidy P and N alternate alleles (0 is the REF and 1..N
-  the alternate alleles), the ordering of genotypes for the likelihoods can
-  be expressed by the following pseudocode with as many nested loops as ploidy:\footnote{Note that we use inclusive \texttt{for} loop boundaries.}
-  \begingroup
-  \small
-  \begin{lstlisting}
-  for $a_P = 0\ldots N$
-    for $a_{P-1} = 0\ldots a_P$
-        $\ldots$
-        for $a_1 = 0\ldots a_{2}$
-            println $a_1 a_2  \ldots  a_P$
-  \end{lstlisting}
-  \endgroup
-
-  Alternatively, the same can be achieved recursively with the following pseudocode:
-  \begingroup
-  \small
-  \begin{lstlisting}
-    Ordering($P$, $N$, suffix=""):
-        for $a$ in $0\ldots N$
-            if ($P == 1$) println str($a$) + suffix
-            if ($P > 1$) Ordering($P$-1, $a$, str($a$) + suffix)
-  \end{lstlisting}
-  \endgroup
-
-  Conversely, the index of the value corresponding to the genotype $k_1\le k_2\le\ldots\le k_P$ is
-  \begingroup
-  \small
-  \begin{lstlisting}
-    Index($k_1/k_2/\ldots/k_P$) = $\sum_{m=1}^{P} {k_m + m - 1 \choose m}$
-  \end{lstlisting}
-  \endgroup
-
-  Examples:
-    \begin{itemize}
-    \item for $P$=2 and $N$=1, the ordering is 00,01,11
-    \item for $P$=2 and $N$=2, the ordering is 00,01,11,02,12,22
-    \item for $P$=3 and $N$=2, the ordering is 000, 001, 011, 111, 002, 012, 112, 022, 122, 222
-    \item for $P$=1, the index of the genotype $a$ is $a$
-    \item for $P$=2, the index of the genotype "$a/b$", where $a\le b$, is $b (b+1)/2 + a$
-    \item for $P$=2 and arbitrary $N$, the ordering can be easily derived from a triangular matrix
-            \newline
-            \hbox{\hskip5em\footnotesize
-            \begin{tabular}{l|llll}
-               $b\setminus a$ & 0 & 1 & 2 & 3 \\ \hline \\[-0.5em]
-               0   & 0 &   &   &   \\
-               1   & 1 & 2 &   &   \\
-               2   & 3 & 4 & 5 &   \\
-               3   & 6 & 7 & 8 & 9 
-            \end{tabular}
-            }
-    \end{itemize}
-
-  \item HQ : haplotype qualities, two comma separated phred qualities (Integers)
-  \item MQ : RMS mapping quality, similar to the version in the INFO field. (Integer)
-  \item PL : the phred-scaled genotype likelihoods rounded to the closest integer (and otherwise defined precisely as the GL field) (Integers)
-  \item PQ : phasing quality, the phred-scaled probability that alleles are ordered incorrectly in a heterozygote (against all other members in the phase set).  We note that we have not yet included the specific measure for precisely defining ``phasing quality''; our intention for now is simply to reserve the PQ tag for future use as a measure of phasing quality. (Integer)
-  \item PS : phase set.  A phase set is defined as a set of phased genotypes to which this genotype belongs.  Phased genotypes for an individual that are on the same chromosome and have the same PS value are in the same phased set.  A phase set specifies multi-marker haplotypes for the phased genotypes in the set.  All phased genotypes that do not contain a PS subfield are assumed to belong to the same phased set.  If the genotype in the GT field is unphased, the corresponding PS field is ignored.  The recommended convention is to use the position of the first variant in the set as the PS identifier (although this is not required). (Non-negative 32-bit Integer)
-  \item $\ldots$ see Section~\ref{sv-format-keys} for a list of genotype keys reserved for structural variants.
+\item for $P$=2 and $N$=1, the ordering is 00,01,11
+\item for $P$=2 and $N$=2, the ordering is 00,01,11,02,12,22
+\item for $P$=3 and $N$=2, the ordering is 000, 001, 011, 111, 002, 012, 112, 022, 122, 222
+\item for $P$=1, the index of the genotype $a$ is $a$
+\item for $P$=2, the index of the genotype "$a/b$", where $a\le b$, is $b (b+1)/2 + a$
+\item for $P$=2 and arbitrary $N$, the ordering can be easily derived from a triangular matrix
+  \newline
+  \hbox{\hskip5em\footnotesize
+  \begin{tabular}{l|llll}
+      $b\setminus a$ & 0 & 1 & 2 & 3 \\ \hline \\[-0.5em]
+      0   & 0 &   &   &   \\
+      1   & 1 & 2 &   &   \\
+      2   & 3 & 4 & 5 &   \\
+      3   & 6 & 7 & 8 & 9 
+  \end{tabular}
+  }
 \end{itemize}
 
+\paragraph{GT subfield} \label{para:genotype-GT}
+Genotype, encoded as allele values separated by either of $/$ or $\mid$. The allele values are 0 for the reference allele (REF field), 1 for the first allele listed in ALT, 2 for the second allele listed in ALT, and so on. For diploid calls examples could be $0/1$, $1\mid0$, $1/2$, etc. For haploid calls, e.g. on Y, male non-pseudoautosomal X, or mitochondrion, only one allele value should be given; a triploid call might look like $0/0/1$. If a call cannot be made for a sample at a given locus, `.' must be specified for each missing allele in the GT field (for example `$./.$' for a diploid genotype and `.' for haploid genotype). The meanings of the separators are as follows:
+\begin{itemize}
+  \item $/$ : genotype unphased
+  \item $\mid$ : genotype phased
+\end{itemize}
+See the PS subfield below for more details on incorporating phasing information into the genotypes.
 
-If any of the fields is missing, it is replaced with the missing value. For example if the FORMAT is GT:GQ:DP:HQ then $0\mid0:.:23:23,34$ indicates that GQ is missing. Trailing fields can be dropped (with the exception of the GT field, which should always be present if specified in the FORMAT field).
+\paragraph{PQ subfield} \label{para:genotype-PQ}
+Phasing quality, the phred-scaled probability that alleles are ordered incorrectly in a heterozygote (against all other members in the phase set). Please note that we have not yet included the specific measure for precisely defining ``phasing quality''; our intention for now is simply to reserve the PQ tag for future use as a measure of phasing quality.
 
-See below for additional genotype fields used to encode structural variants. Additional Genotype fields can be defined in the meta-information. However, software support for such fields is not guaranteed.
+\paragraph{PS subfield} \label{para:genotype-PS}
+A phase set is defined as a set of phased genotypes to which this genotype belongs. Phased genotypes for an individual that are on the same chromosome and have the same PS value are in the same phased set. A phase set specifies multi-marker haplotypes for the phased genotypes in the set. All phased genotypes that do not contain a PS subfield are assumed to belong to the same phased set.  If the genotype in the GT field is unphased, the corresponding PS field is ignored.  The recommended convention is to use the position of the first variant in the set as the PS identifier (although this is not required).
+
 
 \section{Understanding the VCF format and the haplotype representation}
 VCF records use a single general system for representing genetic variation data composed of:

--- a/VCFv4.3.tex
+++ b/VCFv4.3.tex
@@ -1,6 +1,7 @@
 \documentclass[8pt]{article}
 \usepackage{enumerate}
 \usepackage{graphicx}
+\usepackage{tabularx}
 \usepackage{lscape}
 \usepackage[margin=0.75in]{geometry}
 \usepackage[pdfborder={0 0 0}]{hyperref}
@@ -326,38 +327,43 @@ There are 8 fixed fields per record.  Fixed fields are:
   \item ALT - alternate base(s): Comma separated list of alternate non-reference alleles called on at least one of the samples. Options are base Strings made up of the bases A,C,G,T,N,*, (case insensitive) or an angle-bracketed ID String (``$<$ID$>$'') or a breakend replacement string as described in the section on breakends. The `*' allele is reserved to indicate that the allele is missing due to a an overlapping deletion. If there are no alternative alleles, then the missing value should be used.  Tools processing VCF files are not required to preserve case in the allele String, except for IDs, which are case sensitive.  (String; no whitespace, commas, or angle-brackets are permitted in the ID String itself)
   \item QUAL - quality: Phred-scaled quality score for the assertion made in ALT. i.e. $-10log_{10}$ prob(call in ALT is wrong). If ALT is `.' (no variant) then this is $-10log_{10}$ prob(variant), and if ALT is not `.' this is $-10log_{10}$ prob(no variant). If unknown, the missing value should be specified. (Float)
   \item FILTER - filter status: PASS if this position has passed all filters, i.e. a call is made at this position. Otherwise, if the site has not passed all filters, a semicolon-separated list of codes for filters that fail. e.g. ``q10;s50'' might indicate that at this site the quality is below 10 and the number of samples with data is below 50\% of the total number of samples. `0' is reserved and should not be used as a filter String. If filters have not been applied, then this field should be set to the missing value. (String, no white-space or semi-colons permitted, duplicate values not allowed.)
-  \item INFO - additional information: (String, no semi-colons or
-  equals-signs permitted; commas are permitted only as delimiters for lists of
+  \item INFO - additional information: (String, no semi-colons or equals-signs permitted; commas are permitted only as delimiters for lists of
   values; characters with special meaning can be encoded using the percent encoding, see Section~\ref{character-encoding}; space characters are allowed)
-  INFO fields are encoded as a semicolon-separated series of short keys
-  with optional values in the format: $<$key$>$=$<$data$>$[,data]. 
-  INFO keys must match the regular expression \texttt{\^{}[A-Za-z\_][0-9A-Za-z\_.]*\$}, duplicate fields are not allowed.
-  Arbitrary keys are permitted, although the following sub-fields are reserved (albeit optional):
-\begin{itemize}
-  \item AA : ancestral allele
-  \item AC : allele count in genotypes, for each ALT allele, in the same order as listed
-  \item AD, ADF, ADR: read depths for each allele; total (AD), on the forward (ADF) and the reverse (ADR) strand (Integer, Number=R)
-  \item AF : allele frequency for each ALT allele in the same order as listed: use this when estimated from primary data, not called genotypes
-  \item AN : total number of alleles in called genotypes
-  \item BQ : RMS base quality at this position
-  \item CIGAR : cigar string describing how to align an alternate allele to the reference allele
-  \item DB : dbSNP membership
-  \item DP : combined depth across samples, e.g. DP=154
-  \item END : end position of the variant described in this record (for use with symbolic alleles)
-  \item H2 : membership in hapmap2
-  \item H3 : membership in hapmap3
-  \item MQ : RMS mapping quality, e.g. MQ=52
-  \item MQ0 : Number of MAPQ == 0 reads covering this record
-  \item NS : Number of samples with data
-  \item SB : strand bias at this position
-  \item SOMATIC : indicates that the record is a somatic mutation, for cancer genomics
-  \item VALIDATED : validated by follow-up experiment
-  \item 1000G : membership in 1000 Genomes
-  \item $\ldots$ see Section~\ref{sv-info-keys} for a list of INFO keys reserved for structural variants.
-\end{itemize}
-\end{enumerate}
+  INFO fields are encoded as a semicolon-separated series of short keys with optional values in the format: $<$key$>$=$<$data$>$[,data]. 
+  INFO keys must match the regular expression \texttt{\^{}[A-Za-z\_][0-9A-Za-z\_.]*\$}, duplicate fields are not allowed. Arbitrary keys are permitted, although the sub-fields listed in Table~\ref{table:reserved-info} are reserved (albeit optional).
+  
+  \begin{table}[htbp]
+    \centering
+    \begin{tabularx}{\textwidth}{ | l | l | l | X | }
+	Field		& Number	& Type		& Description \\ \hline
+	AA		& 1		& String	& Ancestral allele \\
+	AC		& A		& Integer	& Allele count in genotypes, for each ALT allele, in the same order as listed  \\
+	AD		& R		& Integer	& Total read depth for each allele \\
+	ADF		& R		& Integer	& Read depth for each allele on the forward strand \\
+	ADR		& R		& Integer	& Read depth for each allele on the reverse strand \\
+	AF		& A		& Float		& Allele frequency for each ALT allele in the same order as listed (use this when estimated from primary data, not called genotypes) \\
+	AN		& 1		& Integer	& Total number of alleles in called genotypes \\
+	BQ   		& 1		& Float		& RMS base quality \\
+	CIGAR		& 1		& String	& Cigar string describing how to align an alternate allele to the reference allele \\
+	DB		& 0		& Flag		& dbSNP membership \\
+	DP		& 1		& Integer	& Combined depth across samples \\
+	END		& 1		& Integer	& End position (for use with symbolic alleles) \\
+	H2		& 0		& Flag		& HapMap2 membership \\
+	H3		& 0		& Flag		& HapMap3 membership \\
+	MQ		& 1		& Integer	& RMS mapping quality \\
+	MQ0   		& 1		& Integer	& Number of MAPQ == 0 reads \\
+	NS		& 1		& Integer	& Number of samples with data \\
+	SB		& 1		& Float		& Strand bias \\
+	SOMATIC		& 0		& Flag		& Somatic mutation (for cancer genomics) \\
+	VALIDATED	& 0		& Flag		& Validated by follow-up experiment \\
+	1000G		& 0		& Flag		& 1000 Genomes membership \\
+    \end{tabularx}
+    \caption{Reserved INFO fields}
+    \label{table:reserved-info}
+  \end{table}
+  
 The exact format of each INFO sub-field should be specified in the meta-information (as described above).
-Example for an INFO field: DP=154;MQ=52;H2. Keys without corresponding values are allowed in order to indicate group membership (e.g. H2 indicates the SNP is found in HapMap 2). It is not necessary to list all the properties that a site does NOT have, by e.g. H2=0. See below for additional reserved INFO sub-fields used to encode structural variants.
+Example for an INFO field: DP=154;MQ=52;H2. Keys without corresponding values are allowed in order to indicate group membership (e.g. H2 indicates the SNP is found in HapMap 2). It is not necessary to list all the properties that a site does NOT have, by e.g. H2=0. See Section~\ref{sv-info-keys} for additional reserved INFO sub-fields used to encode structural variants.
 \subsubsection{Genotype fields}
 If genotype information is present, then the same types of data must be present
 for all samples. First a FORMAT field is given specifying the data types and


### PR DESCRIPTION
New tables used instead of plain text to describe strictly the type and number for INFO and SAMPLE reserved fields.

Related to #107 
