### PR TITLE
Indicate that CRAM v3 is now the canonical spec

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,7 +51,7 @@
 
 <p><strong>SAMv1.tex</strong> is the canonical specification for the SAM (Sequence Alignment/Map) format, BAM (its binary equivalent), and the BAI format for indexing BAM files.</p>
 
-<p><strong>CRAMv2.1.tex</strong> is the canonical specification for the CRAM format.
+<p><strong>CRAMv3.tex</strong> is the current canonical specification for the CRAM format and <strong>CRAMv2.1.tex</strong> is it's now obsolete predecessor.
 Further details can be found at <a href="http://www.ebi.ac.uk/ena/about/cram_toolkit">ENA's CRAM toolkit page</a>.</p>
 
 <p>The <strong>tabix.tex</strong> and <strong>CSIv1.tex</strong> quick references summarize more recent index formats: the <a href="https://github.com/samtools/tabix">tabix</a> tool indexes generic textual genome position-sorted files, while CSI is <a href="https://github.com/samtools/htslib">htslib</a>'s successor to the BAI index format.</p>


### PR DESCRIPTION
CRAM v3 has now superseded CRAM v2.1 as the canonical spec