### PR TITLE
Added the AH header tag to @SQ

### DIFF
--- a/SAMv1.tex
+++ b/SAMv1.tex
@@ -200,6 +200,7 @@ meanings can be avoided.}
   & {\tt AS} & Genome assembly identifier. \\\cline{2-3}
   & {\tt M5} & MD5 checksum of the sequence in the uppercase, excluding spaces but including pads (as `*'s).\\\cline{2-3}
   & {\tt SP} & Species.\\\cline{2-3}
+  & {\tt AH} & Indicate if the reference sequence represents an alternate haplotype. \emph{Valid values}: {\tt Y} or {\tt N}\\\cline{2-3}
   & {\tt UR} & URI of the sequence.  This value may start with one of the standard
   protocols, e.g http: or ftp:.  If it does not start with one of these protocols, it is assumed to be a file-system path.\\\cline{1-3}
   \multicolumn{2}{|l}{\tt @RG} & Read group. Unordered multiple {\tt @RG} lines are allowed.\\\cline{2-3}

--- a/SAMv1.tex
+++ b/SAMv1.tex
@@ -197,10 +197,10 @@ meanings can be avoided.}
   field is used in the
   alignment records in {\sf RNAME} and {\sf RNEXT} fields. Regular expression: {\tt [!-)+-\char60\char62-\char126][!-\char126]*}\\\cline{2-3}
   & {\tt LN}* & Reference sequence length. \emph{Range}: {\tt [1,2$^{31}$-1]}\\\cline{2-3}
+  & {\tt AH} & Position of an alternate locus (see also \href{http://bit.ly/GRCterm}{http://bit.ly/GRCterm}) in the format of `\emph{chr}:\emph{start}-\emph{end}', `\emph{chr}' or `{\tt *}' (if unknown), where `\emph{chr}' is a contig in the primary assembly. Present \emph{only if} the sequence is an alternate locus.\\\cline{2-3}
   & {\tt AS} & Genome assembly identifier. \\\cline{2-3}
   & {\tt M5} & MD5 checksum of the sequence in the uppercase, excluding spaces but including pads (as `*'s).\\\cline{2-3}
   & {\tt SP} & Species.\\\cline{2-3}
-  & {\tt AH} & Position of an alternative haplotype in the format of `\emph{chr}:\emph{start}-\emph{end}' or `{\tt *}' (if unknown). Present \emph{only if} the sequence is an alternative haplotype.\\\cline{2-3}
   & {\tt UR} & URI of the sequence.  This value may start with one of the standard
   protocols, e.g http: or ftp:.  If it does not start with one of these protocols, it is assumed to be a file-system path.\\\cline{1-3}
   \multicolumn{2}{|l}{\tt @RG} & Read group. Unordered multiple {\tt @RG} lines are allowed.\\\cline{2-3}

--- a/SAMv1.tex
+++ b/SAMv1.tex
@@ -200,7 +200,7 @@ meanings can be avoided.}
   & {\tt AS} & Genome assembly identifier. \\\cline{2-3}
   & {\tt M5} & MD5 checksum of the sequence in the uppercase, excluding spaces but including pads (as `*'s).\\\cline{2-3}
   & {\tt SP} & Species.\\\cline{2-3}
-  & {\tt AH} & Indicate if the reference sequence represents an alternate haplotype. \emph{Valid values}: {\tt Y} or {\tt N}\\\cline{2-3}
+  & {\tt AH} & Position of an alternative haplotype in the format of `\emph{chr}:\emph{start}-\emph{end}' or `{\tt *}' (if unknown). Present \emph{only if} the sequence is an alternative haplotype.\\\cline{2-3}
   & {\tt UR} & URI of the sequence.  This value may start with one of the standard
   protocols, e.g http: or ftp:.  If it does not start with one of these protocols, it is assumed to be a file-system path.\\\cline{1-3}
   \multicolumn{2}{|l}{\tt @RG} & Read group. Unordered multiple {\tt @RG} lines are allowed.\\\cline{2-3}


### PR DESCRIPTION
This PR adds the AH header tag to @SQ. It indicates whether a reference sequence is an alternate haplotype. Reads mapped to the primary assembly and alternate haplotypes usually receive different treatment in processing. BWA will generate this tag. I am also open to other options.
