### PR TITLE
Changed Z and H aux types to handle zero-length strings.

### DIFF
--- a/SAMv1.tex
+++ b/SAMv1.tex
@@ -427,8 +427,8 @@ defines the format of {\tt VALUE}:
 A & {\tt [!-\char126]} & Printable character \\
 i & {\tt [-+]?[0-9]+} & Signed integer\footnotemark\\
 f & {\tt [-+]?[0-9]*\char92.?[0-9]+([eE][-+]?[0-9]+)?} & Single-precision floating number \\
-Z & {\tt [\,\,\,!-\char126]+} & Printable string, including space\\
-H & {\tt [0-9A-F]+} & Byte array in the Hex format\footnotemark\\
+Z & {\tt [\,\,\,!-\char126]*} & Printable string, including space\\
+H & {\tt ([0-9A-F][0-9A-F])*} & Byte array in the Hex format\footnotemark\\
 B & {\tt [cCsSiIf](,[-+]?[0-9]*\char92.?[0-9]+([eE][-+]?[0-9]+)?)+} & Integer or numeric array\\
 \hline
 \end{tabular}


### PR DESCRIPTION
These are supported in BAM implementations but not permitted in SAM.

Also changed H to require an even number of bytes as this was
(probably) an oversight and is enforced by some implementations
(htsjdk, maybe more).

Fixes #135