### PR TITLE
Corrected the CRAM File Definition major/minor version numbers.

### DIFF
--- a/CRAMv2.1.tex
+++ b/CRAMv2.1.tex
@@ -392,11 +392,29 @@ byte[4] & format magic number & CRAM (0x43 0x52 0x41 0x4d)\tabularnewline
 \hline
 unsigned byte & major format number & 2 (0x2)\tabularnewline
 \hline
-unsigned byte & minor format number & 0 (0x0)\tabularnewline
+unsigned byte & minor format number & 1 (0x1)\tabularnewline
 \hline
 byte[20] & file id & CRAM file identifier (e.g. file name or SHA1 checksum)\tabularnewline
 \hline
 \end{tabular}
+
+Valid CRAM \textit{major}.\textit{minor} version numbers are as follows:
+
+\begin{itemize}
+\item[\textit{1.0}]
+The original public CRAM release.
+
+\item[\textit{2.0}]
+The first CRAM release implemented in both Java and C; tidied up
+implementation vs specification differences in \textit{1.0}.
+
+\item[\textit{2.1}]
+Gained end of file markers; compatible with \textit{2.0}.
+
+\item[\textit{3.0}]
+Additional compression methods; header and data checksums;
+improvements for unsorted data.
+\end {itemize}
 
 \section{\textbf{Container structure}}
 

--- a/CRAMv3.tex
+++ b/CRAMv3.tex
@@ -397,13 +397,31 @@ fields:
 \hline
 byte[4] & format magic number & CRAM (0x43 0x52 0x41 0x4d)\tabularnewline
 \hline
-unsigned byte & major format number & 2 (0x2)\tabularnewline
+unsigned byte & major format number & 3 (0x3)\tabularnewline
 \hline
 unsigned byte & minor format number & 0 (0x0)\tabularnewline
 \hline
 byte[20] & file id & CRAM file identifier (e.g. file name or SHA1 checksum)\tabularnewline
 \hline
 \end{tabular}
+
+Valid CRAM \textit{major}.\textit{minor} version numbers are as follows:
+
+\begin{itemize}
+\item[\textit{1.0}]
+The original public CRAM release.
+
+\item[\textit{2.0}]
+The first CRAM release implemented in both Java and C; tidied up
+implementation vs specification differences in \textit{1.0}.
+
+\item[\textit{2.1}]
+Gained end of file markers; compatible with \textit{2.0}.
+
+\item[\textit{3.0}]
+Additional compression methods; header and data checksums;
+improvements for unsorted data.
+\end {itemize}
 
 \section{\textbf{Container structure}}
 


### PR DESCRIPTION
Correction for issue #141 and candidate text for a very brief version summary for review by @vadimzalunin.  If you're happy with it Vadim, feel free to merge.   (We can discuss tomorrow if you're at the meeting.)   Maybe the history should be moved to the start, but it's where it is simply because that's where the valid version numbers are enumerated.   I'm happy with it in either place.

Also added a very brief one-line summary of the differences between
version numbers.   Not intended to be exhaustive.  Fixes #141