### PR TITLE
Make error handling more concrete & remove some HTTP codes.

### DIFF
--- a/htsget.md
+++ b/htsget.md
@@ -50,9 +50,8 @@ Non-successful invocations of the API return an HTTP error code, and the respons
 
 The following error types are defined:
 
-|-
 Type			| HTTP status code | Description
-|-
+|-----|:---:|-----|
 InvalidAuthentication	| 401	| Authorization provided is invalid
 PermissionDenied	| 403	| Authorization is required to access the resource
 NotFound		| 404	| The resource requested was not found
@@ -61,7 +60,6 @@ UnsupportedFormat	| 409	| The requested file format is not supported by the serv
 InvalidInput		| 422	| The request parameters do not adhere to the specification
 InternalError		| 500	| Server error, clients should try later
 ServiceUnavailable	| 503	| Service is temporarily unavailable
-|-
 
 ## CORS
 
@@ -156,9 +154,8 @@ A comma separated list of tags to exclude, default: none. It is illegal for the 
 
 The list of fields is based on BAM fields:
 
-|-
 Field	| Description
-|-
+|-------|-------|
 QNAME	| Read names
 FLAG	| Read bit flags
 RNAME	| Reference sequence name
@@ -170,7 +167,6 @@ PNEXT	| Alignment position of the next fragment in the template
 TLEN	| Inferred template size
 SEQ	| Read bases
 QUAL	| Base quality scores
-|-
 
 Example: `fields=QNAME,FLAG,POS`.
 


### PR DESCRIPTION
This is an update of the htsget error handling with a few changes. The initial draft is really just for discussion, as it seemed more efficient to make the changes and discuss them concretely rather than in issues.

Changes:

1. Removed HTTP 409, 406 and 416 as discussed in #186.

2. Changed the text where it referred to HTTP codes to refer to the specific error 'classes' that we have defined. 

3. Tried to be more RFC2119 about the language used to describe when and what type of errors should be raised.

4. Changed the structure of the JSON error object to remove the embedded "error" field (seems superfluous), and added a table to document the fields more systematically.

5. Added an ``InvalidRange`` error for when start > end. (Superfluous?)

Apologies for rolling so many changes together, but I think the error handling needs a bit of work in various ways, and this seemed to be the best way of getting the ball rolling. Any feedback would be much appreciated.