### PR TITLE
New OA tag for storing Orignal Alignment information when modifying records

### DIFF
--- a/SAMtags.tex
+++ b/SAMtags.tex
@@ -354,8 +354,8 @@ The resulting string is the result of joining the following six values with comm
 \item {\sf RNAME}, which must be stated explicitly; the use of `{\tt =}', which is allowed in {\sf RNEXT}, is not allowed here.
 \item POS is 1-based.
 \item Strand is either `{\tt +}' or `{\tt -}', indicating positive/negative strand, corresponding to bit 0x10 of FLAG (unset/set).
-\item CIGAR as a string.
-\item MAPQ as a numeric string.
+\item CIGAR encoded as a string.
+\item MAPQ as a string.
 \item NM, the value of the {\tt NM} tag. It may be omitted, but the comma delimiter must be retained so that the string can be easily parsed into the 6 subfields.
 \end{itemize}
 In the presence of an existing {\tt OA} tag, a subsequent tool may append another set of original alignment information after the semicolon,

--- a/SAMtags.tex
+++ b/SAMtags.tex
@@ -92,7 +92,7 @@ or
   {\tt MQ} & i & Mapping quality of the mate/next segment \\
   {\tt NH} & i & Number of reported alignments that contain the query in the current record \\
   {\tt NM} & i & Edit distance to the reference \\
-  {\tt OA} & Z & Original Alignment \\
+  {\tt OA} & Z & Original alignment \\
   {\tt OC} & Z & Original CIGAR (deprecated; use {\tt OA} instead) \\
   {\tt OP} & i & Original mapping position (deprecated; use {\tt OA} instead) \\
   {\tt OQ} & Z & Original base quality \\
@@ -347,13 +347,13 @@ In the case of multiple unique molecular identifiers (e.g., one on each end of t
 \subsection{Original data}
 
 \begin{description}
-\item[OA:Z:\tagregex{{\tt (}\sf{RNAME}{\tt,\,}\sf{POS}{\tt,\,}\emph{strand}{\tt,\,}\sf{CIGAR}{\tt,\,}\sf{MAPQ}{\tt,\,}\sf{NM}{\tt; )}+}]
-The tag encodes the original alignment information of the record prior to realignment or unalignment by subsequent tool. 
-The resulting string is the result of joining the following 6 values with commas `,' (no additional spaces):
+\item[OA:Z:\tagregex{(\metavar{RNAME},\metavar{POS},\metavar{strand},\metavar{CIGAR},\metavar{MAPQ},\metavar{NM};)+}]
+The original alignment information of the record prior to realignment or unalignment by a subsequent tool.
+The resulting string is the result of joining the following six values with commas `,' (no additional spaces):
 \begin{itemize}
-\item {\sf RNAME}, which must be stated explicitly; the use of \,`{\tt =}', which is allowed in {\sf RNEXT}, is not allowed here. 
+\item {\sf RNAME}, which must be stated explicitly; the use of `{\tt =}', which is allowed in {\sf RNEXT}, is not allowed here.
 \item POS is 1-based.
-\item Strand is either `{\tt +}' or `'{\tt -}`, indicating positive/negative strand, corresponding to bit 0x10 of FLAG (unset/set). 
+\item Strand is either `{\tt +}' or `{\tt -}', indicating positive/negative strand, corresponding to bit 0x10 of FLAG (unset/set).
 \item CIGAR as a string.
 \item MAPQ as a numeric string.
 \item NM, the value of the {\tt NM} tag. It may be omitted, but the comma delimiter must be retained so that the string can be easily parsed into the 6 subfields.
@@ -367,11 +367,11 @@ In particular, realignments resulting in the the removal of Secondary or Supplem
 
 \item[OC:Z:\tagvalue{cigar}]
 Original CIGAR, usually before realignment.
-Deprecated by the more general {\tt OA}.
+Deprecated in favour of the more general {\tt OA}.
 
 \item[OP:i:\tagvalue{pos}]
 Original {\sf POS}, usually before realignment.
-Deprecated by the more general {\tt OA}.
+Deprecated in favour of the more general {\tt OA}.
 
 \item[OQ:Z:\tagvalue{qualities}]
 Original base quality, usually before recalibration.
@@ -474,8 +474,7 @@ This appendix lists when standard tags were initially defined or significantly c
 \setlength{\parindent}{0pt}
 \newcommand*{\gap}{\vspace*{2ex}}
 
-
-\subsection*{September 2018}
+\subsubsection*{October 2018}
 Added the OA tag for recording original/previous alignment information. 
 
 Deprecated the OC and OP tags.

--- a/SAMtags.tex
+++ b/SAMtags.tex
@@ -92,8 +92,9 @@ or
   {\tt MQ} & i & Mapping quality of the mate/next segment \\
   {\tt NH} & i & Number of reported alignments that contain the query in the current record \\
   {\tt NM} & i & Edit distance to the reference \\
-  {\tt OC} & Z & Original CIGAR \\
-  {\tt OP} & i & Original mapping position \\
+  {\tt OA} & Z & Original Alignment \\
+  {\tt OC} & Z & Original CIGAR (deprecated; use {\tt OA} instead) \\
+  {\tt OP} & i & Original mapping position (deprecated; use {\tt OA} instead) \\
   {\tt OQ} & Z & Original base quality \\
   {\tt OX} & Z & Original unique molecular barcode bases \\
   {\tt PG} & Z & Program \\
@@ -214,11 +215,13 @@ Same encoding as {\sf QUAL}.
 Sequence of the mate/next segment in the template.  See also {\tt Q2}
 for any associated quality values.
 
-\item[SA:Z:\tagregex{{\tt (}\emph{rname}{\tt ,}\emph{pos}{\tt ,}\emph{strand}{\tt ,}\emph{CIGAR}{\tt ,}\emph{mapQ}{\tt ,}\emph{NM}{\tt ;)}+}]
-Other canonical alignments in a chimeric alignment, formatted as a semicolon-delimited list.
-Each element in the list represents a part of the chimeric alignment. Conventionally, at a supplementary line, the first element points to the primary line.
-\emph{Strand} is either `{\tt +}' or `{\tt -}', indicating positive/negative strand, corresponding to FLAG bit 0x10.
-\emph{Pos} is a 1-based coordinate.
+\item[SA:Z:\tagregex{{\tt (}\sf{RNAME}{\tt ,}\sf{POS}{\tt ,}\emph{strand}{\tt ,}\sf{CIGAR}{\tt ,}\sf{MAPQ}{\tt ,}\sf{NM}{\tt ;)}+}]
+The tag encodes the values of other canonical alignments in a chimeric alignment, formatted as a semicolon-delimited list. 
+Where \emph{strand} encodes the 0x10 bit of {\sf FLAG}---indicating positive/negative strand---such that it is '+' if the bit is unset and '--' if the bit is set.
+The other values are taken directly from the canonical read.
+Each element in the list represents a part of the chimeric alignment. 
+Conventionally, when present at a supplementary line, the first element points to the primary line.
+\emph{\sf POS} is a 1-based coordinate.
 
 \item[SM:i:\tagvalue{score}]
 Template-independent mapping quality, i.e., the mapping quality if the read were mapped as a single read rather than as part of a read pair or template.
@@ -346,11 +349,30 @@ In the case of multiple unique molecular identifiers (e.g., one on each end of t
 \subsection{Original data}
 
 \begin{description}
+\item[OA:Z:\tagregex{{\tt (}\sf{RNAME}{\tt,\,}\sf{POS}{\tt,\,}\emph{strand}{\tt,\,}\sf{CIGAR}{\tt,\,}\sf{MAPQ}{\tt,\,}\sf{NM}{\tt; )}+}]
+The tag encodes the original alignment information of the record prior to realignment or unalignment by subsequent tool. 
+Here \emph{Strand} is either `{\tt +}' or `{\tt -}', indicating whether the read has been reverse-complemented, which corresponds to FLAG bit 0x10.
+That is, \emph{Strand} is `+' if the bit is unset and `-' if the bit is set.
+The resulting string is the result of joining the 6 values with commas `,' (no additional spaces).
+If  {\tt NM} is unknown it may be omitted, but the comma delimiter must be retained so that the string can be easily parsed into the 6 subfields.
+In the presence of an existing {\tt OA} tag, a subsequent tool may append another set of original alignment information after the semicolon,
+adding to---rather than replacing---the existing {\tt OA} information.
+
+Note 1: While commas are legal characters in sequence names, it is forbidden to have an {\tt OA} tag with such sequences.
+
+Note 2: {\sf RNAME} must be stated explicitly: the use of \,`=', which is allowed in {\sf RNEXT}, is not allowed here.
+
+Note 3: The {\tt OA} field is designed to provide record-level information that can be useful for understanding the provenance of the information in a record. 
+It is not designed to provide a complete history of the template alignment information. 
+In particular, realignments resulting in the the removal of Secondary or Supplementary records will cause the loss of all tags associated with those records, and may alternatively leave the {\tt SA} tag in an invalid state.
+
 \item[OC:Z:\tagvalue{cigar}]
 Original CIGAR, usually before realignment.
+Deprecated by the more general {\tt OA}.
 
 \item[OP:i:\tagvalue{pos}]
-Original 1-based mapping position, usually before realignment.
+Original {\sf POS}, usually before realignment.
+Deprecated by the more general {\tt OA}.
 
 \item[OQ:Z:\tagvalue{qualities}]
 Original base quality, usually before recalibration.
@@ -452,6 +474,10 @@ This appendix lists when standard tags were initially defined or significantly c
 
 \setlength{\parindent}{0pt}
 \newcommand*{\gap}{\vspace*{2ex}}
+
+
+\subsection*{September 2018}
+Add OA tag for recording original/previous alignment information. 
 
 \subsubsection*{July 2018}
 

--- a/SAMtags.tex
+++ b/SAMtags.tex
@@ -355,7 +355,7 @@ The resulting string is the result of joining the following six values with comm
 \item POS is 1-based.
 \item Strand is either `{\tt +}' or `{\tt -}', indicating positive/negative strand, corresponding to bit 0x10 of FLAG (unset/set).
 \item CIGAR encoded as a string.
-\item MAPQ as a string.
+\item MAPQ as a numeric mapping quality.
 \item NM, the value of the {\tt NM} tag. It may be omitted, but the comma delimiter must be retained so that the string can be easily parsed into the 6 subfields.
 \end{itemize}
 In the presence of an existing {\tt OA} tag, a subsequent tool may append another set of original alignment information after the semicolon,

--- a/SAMtags.tex
+++ b/SAMtags.tex
@@ -363,7 +363,7 @@ adding to---rather than replacing---the existing {\tt OA} information.
 
 The {\tt OA} field is designed to provide record-level information that can be useful for understanding the provenance of the information in a record. 
 It is not designed to provide a complete history of the template alignment information. 
-In particular, realignments resulting in the the removal of Secondary or Supplementary records will cause the loss of all tags associated with those records, and may alternatively leave the {\tt SA} tag in an invalid state.
+In particular, realignments resulting in the the removal of Secondary or Supplementary records will cause the loss of all tags associated with those records, and may also leave the {\tt SA} tag in an invalid state.
 
 \item[OC:Z:\tagvalue{cigar}]
 Original CIGAR, usually before realignment.

--- a/SAMtags.tex
+++ b/SAMtags.tex
@@ -474,7 +474,7 @@ This appendix lists when standard tags were initially defined or significantly c
 \setlength{\parindent}{0pt}
 \newcommand*{\gap}{\vspace*{2ex}}
 
-\subsubsection*{October 2018}
+\subsubsection*{January 2019}
 Added the OA tag for recording original/previous alignment information. 
 
 Deprecated the OC and OP tags.

--- a/SAMtags.tex
+++ b/SAMtags.tex
@@ -349,15 +349,14 @@ In the case of multiple unique molecular identifiers (e.g., one on each end of t
 \begin{description}
 \item[OA:Z:\tagregex{(\metavar{RNAME},\metavar{POS},\metavar{strand},\metavar{CIGAR},\metavar{MAPQ},\metavar{NM};)+}]
 The original alignment information of the record prior to realignment or unalignment by a subsequent tool.
-The resulting string is the result of joining the following six values with commas `,' (no additional spaces):
-\begin{itemize}
-\item {\sf RNAME}, which must be stated explicitly; the use of `{\tt =}', which is allowed in {\sf RNEXT}, is not allowed here.
-\item POS is 1-based.
-\item Strand is either `{\tt +}' or `{\tt -}', indicating positive/negative strand, corresponding to bit 0x10 of FLAG (unset/set).
-\item CIGAR encoded as a string.
-\item MAPQ as a numeric mapping quality.
-\item NM, the value of the {\tt NM} tag. It may be omitted, but the comma delimiter must be retained so that the string can be easily parsed into the 6 subfields.
-\end{itemize}
+Each original alignment entry contains the following six field values from the original record, generally in their textual SAM representations, separated by commas (`{\tt ,}') and terminated by a semicolon (`{\tt ;}'):
+{\sf RNAME}, which must be explicit (unlike {\sf RNEXT}, `{\tt =}' may not be used here);
+1-based {\sf POS};
+`{\tt +}' or `{\tt -}', indicating forward/reverse strand respectively (as per bit~0x10 of {\sf FLAG});
+{\sf CIGAR};
+{\sf MAPQ};
+{\tt NM} tag value, which may be omitted (though the preceding comma must be retained).
+
 In the presence of an existing {\tt OA} tag, a subsequent tool may append another set of original alignment information after the semicolon,
 adding to---rather than replacing---the existing {\tt OA} information.
 
@@ -370,7 +369,7 @@ Original CIGAR, usually before realignment.
 Deprecated in favour of the more general {\tt OA}.
 
 \item[OP:i:\tagvalue{pos}]
-Original {\sf POS}, usually before realignment.
+Original 1-based {\sf POS}, usually before realignment.
 Deprecated in favour of the more general {\tt OA}.
 
 \item[OQ:Z:\tagvalue{qualities}]

--- a/SAMtags.tex
+++ b/SAMtags.tex
@@ -215,13 +215,11 @@ Same encoding as {\sf QUAL}.
 Sequence of the mate/next segment in the template.  See also {\tt Q2}
 for any associated quality values.
 
-\item[SA:Z:\tagregex{{\tt (}\sf{RNAME}{\tt ,}\sf{POS}{\tt ,}\emph{strand}{\tt ,}\sf{CIGAR}{\tt ,}\sf{MAPQ}{\tt ,}\sf{NM}{\tt ;)}+}]
-The tag encodes the values of other canonical alignments in a chimeric alignment, formatted as a semicolon-delimited list. 
-Where \emph{strand} encodes the 0x10 bit of {\sf FLAG}---indicating positive/negative strand---such that it is '+' if the bit is unset and '--' if the bit is set.
-The other values are taken directly from the canonical read.
-Each element in the list represents a part of the chimeric alignment. 
-Conventionally, when present at a supplementary line, the first element points to the primary line.
-\emph{\sf POS} is a 1-based coordinate.
+\item[SA:Z:\tagregex{{\tt (}\emph{rname}{\tt ,}\emph{pos}{\tt ,}\emph{strand}{\tt ,}\emph{CIGAR}{\tt ,}\emph{mapQ}{\tt ,}\emph{NM}{\tt ;)}+}]
+Other canonical alignments in a chimeric alignment, formatted as a semicolon-delimited list.
+Each element in the list represents a part of the chimeric alignment. Conventionally, at a supplementary line, the first element points to the primary line.
+\emph{Strand} is either `{\tt +}' or `{\tt -}', indicating positive/negative strand, corresponding to FLAG bit 0x10.
+\emph{Pos} is a 1-based coordinate.
 
 \item[SM:i:\tagvalue{score}]
 Template-independent mapping quality, i.e., the mapping quality if the read were mapped as a single read rather than as part of a read pair or template.
@@ -351,14 +349,14 @@ In the case of multiple unique molecular identifiers (e.g., one on each end of t
 \begin{description}
 \item[OA:Z:\tagregex{{\tt (}\sf{RNAME}{\tt,\,}\sf{POS}{\tt,\,}\emph{strand}{\tt,\,}\sf{CIGAR}{\tt,\,}\sf{MAPQ}{\tt,\,}\sf{NM}{\tt; )}+}]
 The tag encodes the original alignment information of the record prior to realignment or unalignment by subsequent tool. 
-The resulting string is the result of joining the following6 values with commas `,' (no additional spaces):
+The resulting string is the result of joining the following 6 values with commas `,' (no additional spaces):
 \begin{itemize}
-\item {\sf RNAME} must be stated explicitly: the use of \,`=', which is allowed in {\sf RNEXT}, is not allowed here. 
+\item {\sf RNAME}, which must be stated explicitly; the use of \,`{\tt =}', which is allowed in {\sf RNEXT}, is not allowed here. 
 \item POS is 1-based.
-\item Strand is either ?+? or ?-?, indicating positive/negative strand, corresponding to FLAG bit 0x10. 
+\item Strand is either `{\tt +}' or `'{\tt -}`, indicating positive/negative strand, corresponding to bit 0x10 of FLAG (unset/set). 
 \item CIGAR as a string.
-\item mapq as a numeric string.
-\item NM (as a numeric string). It may be omitted, but the comma delimiter must be retained so that the string can be easily parsed into the 6 subfields.
+\item MAPQ as a numeric string.
+\item NM, the value of the {\tt NM} tag. It may be omitted, but the comma delimiter must be retained so that the string can be easily parsed into the 6 subfields.
 \end{itemize}
 In the presence of an existing {\tt OA} tag, a subsequent tool may append another set of original alignment information after the semicolon,
 adding to---rather than replacing---the existing {\tt OA} information.
@@ -478,7 +476,9 @@ This appendix lists when standard tags were initially defined or significantly c
 
 
 \subsection*{September 2018}
-Add OA tag for recording original/previous alignment information. 
+Added the OA tag for recording original/previous alignment information. 
+
+Deprecated the OC and OP tags.
 
 \subsubsection*{July 2018}
 

--- a/SAMtags.tex
+++ b/SAMtags.tex
@@ -351,18 +351,19 @@ In the case of multiple unique molecular identifiers (e.g., one on each end of t
 \begin{description}
 \item[OA:Z:\tagregex{{\tt (}\sf{RNAME}{\tt,\,}\sf{POS}{\tt,\,}\emph{strand}{\tt,\,}\sf{CIGAR}{\tt,\,}\sf{MAPQ}{\tt,\,}\sf{NM}{\tt; )}+}]
 The tag encodes the original alignment information of the record prior to realignment or unalignment by subsequent tool. 
-Here \emph{Strand} is either `{\tt +}' or `{\tt -}', indicating whether the read has been reverse-complemented, which corresponds to FLAG bit 0x10.
-That is, \emph{Strand} is `+' if the bit is unset and `-' if the bit is set.
-The resulting string is the result of joining the 6 values with commas `,' (no additional spaces).
-If  {\tt NM} is unknown it may be omitted, but the comma delimiter must be retained so that the string can be easily parsed into the 6 subfields.
+The resulting string is the result of joining the following6 values with commas `,' (no additional spaces):
+\begin{itemize}
+\item {\sf RNAME} must be stated explicitly: the use of \,`=', which is allowed in {\sf RNEXT}, is not allowed here. 
+\item POS is 1-based.
+\item Strand is either ?+? or ?-?, indicating positive/negative strand, corresponding to FLAG bit 0x10. 
+\item CIGAR as a string.
+\item mapq as a numeric string.
+\item NM (as a numeric string). It may be omitted, but the comma delimiter must be retained so that the string can be easily parsed into the 6 subfields.
+\end{itemize}
 In the presence of an existing {\tt OA} tag, a subsequent tool may append another set of original alignment information after the semicolon,
 adding to---rather than replacing---the existing {\tt OA} information.
 
-Note 1: While commas are legal characters in sequence names, it is forbidden to have an {\tt OA} tag with such sequences.
-
-Note 2: {\sf RNAME} must be stated explicitly: the use of \,`=', which is allowed in {\sf RNEXT}, is not allowed here.
-
-Note 3: The {\tt OA} field is designed to provide record-level information that can be useful for understanding the provenance of the information in a record. 
+The {\tt OA} field is designed to provide record-level information that can be useful for understanding the provenance of the information in a record. 
 It is not designed to provide a complete history of the template alignment information. 
 In particular, realignments resulting in the the removal of Secondary or Supplementary records will cause the loss of all tags associated with those records, and may alternatively leave the {\tt SA} tag in an invalid state.
 

--- a/SAMv1.tex
+++ b/SAMv1.tex
@@ -36,7 +36,7 @@
 
 \begin{document}
 
-\input{SAMv1.ver}
+\input{./SAMv1.ver}
 \title{Sequence Alignment/Map Format Specification}
 \author{The SAM/BAM Format Specification Working Group}
 \date{\headdate}
@@ -58,6 +58,8 @@ alignments. Header lines start with `{\tt @}', while alignment lines do
 not. Each alignment line has 11 mandatory fields for essential alignment
 information such as mapping position, and variable number of optional
 fields for flexible or aligner specific information.
+
+Yossi Was Here (testing latex diff)
 
 This specification is for version 1.6 of the SAM and BAM formats.  Each SAM and
 BAM file may optionally specify the version being used via the

--- a/SAMv1.tex
+++ b/SAMv1.tex
@@ -36,7 +36,7 @@
 
 \begin{document}
 
-\input{./SAMv1.ver}
+\input{SAMv1.ver}
 \title{Sequence Alignment/Map Format Specification}
 \author{The SAM/BAM Format Specification Working Group}
 \date{\headdate}
@@ -58,8 +58,6 @@ alignments. Header lines start with `{\tt @}', while alignment lines do
 not. Each alignment line has 11 mandatory fields for essential alignment
 information such as mapping position, and variable number of optional
 fields for flexible or aligner specific information.
-
-Yossi Was Here (testing latex diff)
 
 This specification is for version 1.6 of the SAM and BAM formats.  Each SAM and
 BAM file may optionally specify the version being used via the


### PR DESCRIPTION
This could be used in GATK's IndelRealignment, but the main use I have for it is in Picard's MergeBamAlignment where it now unmaps reads that look like bacterial contamination that got mapped due to a match of 20 or so bases randomly. Since this unmaping is lossy (as one can't keep original alignment information in place) I would like to store the alignment information in a tag. I used the same format as the OA tag.

