### PR TITLE
Explicitly state character encoding, locale, and RE syntax.

### DIFF
--- a/SAMv1.tex
+++ b/SAMv1.tex
@@ -40,6 +40,9 @@ This specification is for version 1.5 of the SAM and BAM formats.  Each SAM and
 BAM file may optionally specify the version being used via the
 {\tt @HD VN} tag. For full version history see Appendix~\ref{sec:history}. 
 
+Unless explicitly specified elsewhere, all fields are encoded using 7-bit US-ASCII \footnote{Charset ANSI\_X3.4-1968 as defined in RFC1345.} in using the POSIX / C locale.
+Regular expressions listed use the POSIX / IEEE Std 1003.1 extended syntax.
+
 \subsection{An example}\label{sec:example}
 Suppose we have the following alignment with bases in lower cases
 clipped from the alignment. Read {\tt r001/1} and {\tt r001/2}
@@ -230,7 +233,7 @@ where \emph{name} is {\tt [0-9A-Za-z][0-9A-Za-z*+.@\_|-]*}\\\cline{2-3}
   & {\tt ID}* & Read group identifier. Each {\tt @RG} line must have a unique {\tt ID}. The value of {\tt ID}
   is used in the RG tags of alignment records. Must be unique among all read groups in header section.  Read group IDs may be modified when merging SAM files in order to handle collisions.\\\cline{2-3}
   & {\tt CN} & Name of sequencing center producing the read.\\\cline{2-3}
-  & {\tt DS} & Description.\\\cline{2-3}
+  & {\tt DS} & Description.  UTF-8 encoding may be used.\\\cline{2-3}
   & {\tt DT} & Date the run was produced (ISO8601 date or date/time).\\\cline{2-3}
   & {\tt FO} & Flow order. The array of nucleotide bases that correspond to the nucleotides used for each flow of each read.
   	Multi-base flows are encoded in IUPAC format, and non-nucleotide flows by various other characters. \emph{Format}: {\tt /\char92*|[ACMGRSVTWYHKDBN]+/}\\\cline{2-3}
@@ -249,7 +252,7 @@ where \emph{name} is {\tt [0-9A-Za-z][0-9A-Za-z*+.@\_|-]*}\\\cline{2-3}
   	The value of {\tt ID} is used in the alignment {\tt PG} tag and {\tt PP} tags of other {\tt @PG} lines.
 	{\tt PG} IDs may be modified when merging SAM files in order to handle collisions.\\\cline{2-3}
   & {\tt PN} & Program name \\\cline{2-3}
-  & {\tt CL} & Command line \\\cline{2-3}
+  & {\tt CL} & Command line.  UTF-8 encoding may be used. \\\cline{2-3}
   & {\tt PP} & Previous {\tt @PG-ID}. Must match another {\tt @PG} header's {\tt ID} tag.
   	{\tt @PG} records may be chained using {\tt PP} tag, with the last record in the chain
 	having no {\tt PP} tag. This chain defines the order of programs that have been applied to the alignment.
@@ -261,9 +264,9 @@ where \emph{name} is {\tt [0-9A-Za-z][0-9A-Za-z*+.@\_|-]*}\\\cline{2-3}
         to refer to the newest {\tt PG} record in a chain.  It may refer to any {\tt PG}
         record in a chain, implying that the SAM record has been operated on by the
         program in that {\tt PG} record, and the program(s) referred to via the {\tt PP} tag. \\\cline{2-3}
-  & {\tt DS} & Description.\\\cline{2-3}
+  & {\tt DS} & Description.  UTF-8 encoding may be used.\\\cline{2-3}
   & {\tt VN} & Program version \\\cline{1-3}
-  \multicolumn{2}{|l}{\tt @CO} & One-line text comment. Unordered multiple {\tt @CO} lines are allowed.\\
+  \multicolumn{2}{|l}{\tt @CO} & One-line text comment. Unordered multiple {\tt @CO} lines are allowed. UTF-8 encoding may be used.\\
   \cline{1-3}
 \end{longtable}
 \end{center}
@@ -1129,6 +1132,7 @@ specification with its own version numbering.\footnote{
 \subsection*{1.5: 23 May 2013 to current}
 
 \begin{itemize}
+\item Permit UTF-8 in a few header tags. (Mar 2018)
 \item Add {\tt @SQ AH} header tag. (Mar 2017)
 \item Auxiliary tags migrated to SAMtags document. (Sep 2016)
 \item Z and H auxiliary tags are permitted to be zero length. (Jun 2016)


### PR DESCRIPTION
Still to do.
- We need to explicitly add which SAM header fields we permit use of UTF8.
- CRAM?  It's a binary format so I'm didn't change it as I don't think this applies.
- Wording choices: "encodes" maybe isn't the correct word.  Suggestions?

Fixes #197.