### PR TITLE
Remove referenceMD5 query parameter.

### DIFF
--- a/htsget.md
+++ b/htsget.md
@@ -128,23 +128,13 @@ The reference sequence name, for example "chr1", "1", or "chrX". If unspecified,
 The server SHOULD reply with a `NotFound` error if the requested reference does not exist.
 </td></tr>
 <tr markdown="block"><td>
-`referenceMD5`  
-_optional_
-</td><td>
-The MD5 checksum uniquely representing the reference sequence as a lower-case hexadecimal string, calculated as the MD5 of the upper-case sequence excluding all whitespace characters (this is equivalent to SQ:M5 in SAM).
-
-The server SHOULD reply with a `NotFound` error if the requested reference does not exist.
-
-The server SHOULD reply with an `InvalidInput` if `referenceName` and `referenceMD5` are both specified and are incompatible.
-</td></tr>
-<tr markdown="block"><td>
 `start`  
 _optional 32-bit unsigned integer_
 </td><td>
 The start position of the range on the reference, 0-based, inclusive. 
 
 The server SHOULD respond with an `InvalidInput` error if `start` is specified and a reference is not specified
-(see `referenceName` and `referenceMD5`).
+(see `referenceName`).
 
 The server SHOULD respond with an `InvalidRange` error if `start` and `end` are specified and `start` is greater
 than `end`.
@@ -156,7 +146,7 @@ _optional 32-bit unsigned integer_
 The end position of the range on the reference, 0-based exclusive.
 
 The server SHOULD respond with an `InvalidInput` error if `end` is specified and a reference is not specified
-(see `referenceName` and `referenceMD5`).
+(see `referenceName`).
 
 The server SHOULD respond with an `InvalidRange` error if `start` and `end` are specified and `start` is greater
 than `end`.


### PR DESCRIPTION
As discussed in yesterday's conference call, this PR removes the ``referenceMD5`` query parameter. The motivations for this are:

1. It has not been yet been implemented by enough servers, and we would like to hit v 1.0 of the spec soon.
2. It was not very well specified from a client perspective (i.e., should a client expect both referenceName and referenceMD5 to both be supported? Or one or the other? Is one or other considered mandatory for a conforming server?).
3. It is arguably redundant, since actual information discovery is done upstream of htsget where accurate reference sequence specification can be done. The ``referenceName`` part of this protocol can be seen as a local reference ID, and need not have any global interpretation. 