### PR TITLE
Added list of specification maintainers

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,3 +1,38 @@
+## Specification maintainers
+
+The SAM, BAM, and VCF formats originated in the 1000 Genomes Project.
+In February 2014, ongoing format maintenance was brought under the aegis of the [Global Alliance for Genomics & Health][ga4gh-ff].
+At this time, lead maintainers for each of the formats were nominated.
+The current maintainers are listed below.
+
+### SAM/BAM
+
+* James Bonfield (@jkbonfield)
+* John Marshall (@jmarshall)
+* Yossi Farjoun (@yfarjoun)
+
+Past SAM/BAM maintainers include Jay Carey, Tim Fennell, and Nils Homer.
+
+### CRAM
+
+* James Bonfield (@jkbonfield)
+* Vadim Zalunin (@vadimzalunin)
+
+### VCF/BCF
+
+* Cristina Yenyxe Gonzalez Garcia (@cyenyxe)
+* David Roazen (@droazen)
+* Petr Danecek (@pd3)
+
+Past VCF/BCF maintainers include Ryan Poplin.
+
+### Htsget
+
+* Mike Lin (@mlin)
+
+[ga4gh-ff]:  https://genomicsandhealth.org/working-groups/our-work/file-formats
+
+
 ## Generating PDF specification documents
 
 Use the _Makefile_ to generate PDFs from the TeX source documents.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@ SAM/BAM and related specifications
 
 Links **in bold** point to the corresponding PDFs on this repository's [GitHub Pages website][hts-specs].
 
+Please request improvements or report errors using this repository, but see also [the list of maintainers](MAINTAINERS.md) if you need to contact them directly.
+
+
 Alignment data files
 --------------------
 

--- a/index.md
+++ b/index.md
@@ -28,7 +28,7 @@ Specifications:
 - [Htsget](htsget.html)
 </div>
 <div class="mainbar">
-{% for line in readme_lines offset: 5 %}
+{% for line in readme_lines offset: 8 %}
 {{line}}{% endfor %}
 </div>
 <div class="clear"></div>


### PR DESCRIPTION
List of maintainers in `MAINTAINERS.md`. Reference to said list in `README.md`, with a gentle reminder to use GitHub in the first place.