### PR TITLE
RFC: Add @TG header for alignment tag declarations

### DIFF
--- a/SAMv1.tex
+++ b/SAMv1.tex
@@ -243,6 +243,13 @@ meanings can be avoided.}
         program in that {\tt PG} record, and the program(s) referred to via the {\tt PP} tag. \\\cline{2-3}
   & {\tt DS} & Description.\\\cline{2-3}
   & {\tt VN} & Program version \\\cline{1-3}
+  \multicolumn{2}{|l}{\tt @TG} & Optional alignment tag declaration. \\\cline{2-3}
+  & {\tt ID}* & Tag ID used in this file. \emph{Format} {\tt /\^{}[A-Za-z][A-Za-z0-9]\$/}. \\\cline{2-3}
+  & {\tt UU}* & Unique identifier. \\\cline{2-3}
+  & {\tt TP} & Content type.  \emph{Format} {\tt /\^{}[AifZHB]\$/}. \\\cline{2-3}
+  & {\tt UR} & URI giving a canonical definition of the tag. \\\cline{2-3}
+  & {\tt DS} & Short description \\\cline{2-3}
+  & {\tt DI} & Originally desired Tag ID, for information only. \emph{Format} { \tt /\^{}[A-Za-z][A-Za-z0-9]\$/}. \\\cline{1-3}
   \multicolumn{2}{|l}{\tt @CO} & One-line text comment. Unordered multiple {\tt @CO} lines are allowed.\\
   \cline{1-3}
 \end{longtable}
@@ -426,6 +433,7 @@ Each bit is explained in the following table:
 \subsection{The alignment section: optional fields}\label{sec:alnaux}
 All optional fields follow the {\tt TAG:TYPE:VALUE} format
 where {\tt TAG} is a two-character string that matches {\tt /[A-Za-z][A-Za-z0-9]/}.
+All {\tt TAG} identifiers MUST be declared in a header {\tt @TG} record.
 Each {\tt TAG} can only appear once in one alignment line. A {\tt TAG}
 containing lowercase letters are reserved for end users.
 In an optional field, {\tt TYPE} is a single case-sensitive letter which


### PR DESCRIPTION
Solve the problem of incompatible alignment tags with the same identifier by forcing them to be declared in the header.  This allows the small two-character namespace to be effectively increased by tying the ID
used to a much bigger unique identifier.  Software writing files can resolve clashes by changing the ID used while leaving the unique identifier unchanged.

The new header has the format shown below.  It's possible that more of the fields should be compulsory (e.g. TP, UR).

```
@TG Optional field tag declaration
  ID* Tag ID used in this file.  Format /^[A-Za-z][A-Za-z0-9]$/.
  UU* Unique identifier.
  TP  Content type.  Format /^[AifZHB]$/
  UR  URI giving a canonical definition of the tag.
  DS  Short description
  DI  Desired Tag ID.  Format /^[A-Za-z][A-Za-z0-9]$/.
```

UU could either be the string representation of a UUID as described in [RFC4122,](https://www.rfc-editor.org/rfc/rfc4122.txt) or in a similar manner to Java packages as described in http://www.oracle.com/technetwork/java/codeconventions-135099.html.
All software must only use tags with a given UU if they exactly match the semantics of all other software that uses the same UU.  I'm in favour of using UUIDs here, as I suspect vendors may be reluctant to use a different vendors' reversed domain even if the tag usage is in fact identical.

The way I would imagine this working is:

* Software that wants to write a tag registers it first in the header.
  This includes the ones currently in the SAMtags document, although libraries might want to provide a simpler API for them (e.g. `register_common_tags('BC', 'LB', 'MC', NULL);` as opposed to `register_tag(id, uu, type, uri, description);`)

* As all tags will need to be declared in the header, the header becomes compulsory, even for SAM files.  **This would require a version number change.**

* APIs would resolve clashes automatically.
  For ease of identification this could be done by playing with the ID case (e.g. try rX, Rx, rx for RX) before falling back to a counter-based solution (aa, ab, ac etc.).

* Software using tags can then refer to them by the expected ID and the API will take care of the translation.
  This should make for easier adoption, as the only change needed would be to register the tags in the header so that a translation table can be built.