### PR TITLE
Add @SQ-AN alternative reference sequence names

### DIFF
--- a/SAMv1.tex
+++ b/SAMv1.tex
@@ -194,14 +194,28 @@ meanings can be avoided.}
     grouped by {\sf QNAME}), and {\tt reference} (alignments are grouped by
     {\sf RNAME}/{\sf POS}).\\\cline{1-3}
   \multicolumn{2}{|l}{\tt @SQ} & Reference sequence dictionary. The order of {\tt @SQ} lines defines the alignment sorting order.\\\cline{2-3}
-  & {\tt SN}* & Reference sequence name. Each {\tt @SQ} line must have a unique {\tt SN} tag. The value of this
-  field is used in the
+  & {\tt SN}* & Reference sequence name.
+The {\tt SN} tags and all individual {\tt AN} names in all {\tt @SQ} lines
+must be distinct.
+  The value of this field is used in the
   alignment records in {\sf RNAME} and {\sf RNEXT} fields. Regular expression: {\tt [!-)+-\char60\char62-\char126][!-\char126]*}\\\cline{2-3}
   & {\tt LN}* & Reference sequence length. \emph{Range}: {\tt [1,2$^{31}$-1]}\\\cline{2-3}
   & {\tt AH} & Indicates that this sequence is an alternate locus.%
 \footnote{See \url{https://www.ncbi.nlm.nih.gov/grc/help/definitions} for descriptions of \emph{alternate locus} and \emph{primary assembly}.}
   The value is the locus in the primary assembly for which this sequence is an alternative, in the format `\emph{chr}{\tt :}\emph{start}{\tt -}\emph{end}', `\emph{chr}' (if known), or `{\tt *}' (if unknown), where `\emph{chr}' is a sequence in the primary assembly.
   Must not be present on sequences in the primary assembly.\\\cline{2-3}
+  & {\tt AN} & Alternative reference sequence names.
+A comma-separated list of alternative names that tools may use when referring
+to this reference sequence.%
+\footnote{For example, given `{\tt @SQ SN:MT AN:chrMT,M,chrM LN:16569}',
+tools can ensure that a user's request for any of `MT', `chrMT', `M',
+or~`chrM' succeeds and refers to the same sequence.
+Note the restricted set of characters allowed in an alternative name.}
+These alternative names are not used elsewhere within the SAM file;
+in particular, they must not appear in alignment records' {\sf RNAME}
+or~{\sf RNEXT} fields.
+\emph{Regular expression}: \emph{name}{\tt (,}\emph{name}{\tt )*}
+where \emph{name} is {\tt [0-9A-Za-z][0-9A-Za-z*+.@\_|-]*}\\\cline{2-3}
   & {\tt AS} & Genome assembly identifier. \\\cline{2-3}
   & {\tt M5} & MD5 checksum of the sequence in the uppercase, excluding spaces but including pads (as `*'s).\\\cline{2-3}
   & {\tt SP} & Species.\\\cline{2-3}


### PR DESCRIPTION
Proposed text to implement #100, "suggestion: aliases in `@SQ` section".

Also take the opportunity to pre-emptively restrict the characters allowed in these alternative names.

As noted [in last September's meeting](https://github.com/samtools/hts-specs/issues/100#issuecomment-264209422), restricting the characters allowed in `AN` alternative names could be a first step towards applying the same restriction in `SN` canonical sequence names and finally being able to parse the colon in `chr:beg-end` unambiguously.

There is debate to be had about which punctuation characters to forbid; there are existing points for consideration in #100, #124, and #167.

The primary motivation here is to disallow `:` so `chr:beg-end` region syntax is unambiguous, so we have taken advantage of colon being available as the delimiter, inspired by `TAG:TYPE:VALUE` delimiters.

Other motivation might be to disallow `,` so `chr1,chr2,chr3` list syntax is unambiguous.  If disallowing comma has particular support, perhaps using comma as the `AN` delimiter would be preferable.