### PR TITLE
Proposed htsget protocol identifier in JSON text

### DIFF
--- a/htsget.md
+++ b/htsget.md
@@ -27,7 +27,7 @@ Explicitly this API does NOT:
 
 All API invocations are made to a configurable HTTP(S) endpoint, receive URL-encoded query string parameters, and return JSON output. Successful requests result with HTTP status code 200 and have UTF8-encoded JSON in the response body, with the content-type `application/json`. The server may provide responses with chunked transfer encoding. The client and server may mutually negotiate HTTP/2 upgrade using the standard mechanism.
 
-The JSON response SHOULD be an object with the single key `htsget`.  The value is an object as described in the [Response JSON fields](#response-json-fields) and [Error Response JSON fields](#error-response-json-fields) sections.  This ensures that, apart from whitespace differences, the message always starts with the same prefix.  The presence of this prefix can be used as part of a client's response validation.
+The JSON response is an object with the single key `htsget` as described in the [Response JSON fields](#response-json-fields) and [Error Response JSON fields](#error-response-json-fields) sections.  This ensures that, apart from whitespace differences, the message always starts with the same prefix.  The presence of this prefix can be used as part of a client's response validation.
 
 Any timestamps that appear in the response from an API method are given as [ISO 8601] date/time format.
 

--- a/htsget.md
+++ b/htsget.md
@@ -27,6 +27,8 @@ Explicitly this API does NOT:
 
 All API invocations are made to a configurable HTTP(S) endpoint, receive URL-encoded query string parameters, and return JSON output. Successful requests result with HTTP status code 200 and have UTF8-encoded JSON in the response body, with the content-type `application/json`. The server may provide responses with chunked transfer encoding. The client and server may mutually negotiate HTTP/2 upgrade using the standard mechanism.
 
+The JSON response SHOULD be an object with the single key `htsget`.  The value is an object as described in the [Response JSON fields](#response-json-fields) and [Error Response JSON fields](#error-response-json-fields) sections.  This ensures that, apart from whitespace differences, the message always starts with the same prefix.  The presence of this prefix can be used as part of a client's response validation.
+
 Any timestamps that appear in the response from an API method are given as [ISO 8601] date/time format.
 
 HTTP responses may be compressed using [RFC 2616] `transfer-coding`, not `content-coding`.
@@ -45,6 +47,12 @@ For errors that are specific to the `htsget` protocol, the response body SHOULD 
 
 <table>
 <tr markdown="block"><td>
+`htsget`
+_object_
+<td>
+Container for response object.
+<table>
+<tr markdown="block"><td>
 `error`  
 _string_
 </td><td>
@@ -55,6 +63,8 @@ The type of error. This SHOULD be chosen from the list below.
 _string_
 </td><td>
 A message specific to the error providing information on how to debug the problem. Clients MAY display this message to the user.
+</td></tr>
+</table>
 </td></tr>
 </table>
 
@@ -72,8 +82,10 @@ InvalidRange		| 400	| The requested range cannot be satisfied
 The error type SHOULD be chosen from this table and be accompanied by the specified HTTP status code.  An example of a valid JSON error response is:
 ```json
 {
-   "error": "NotFound",
-   "message": "No such accession 'ENS16232164'"
+   "htsget" : {
+      "error": "NotFound",
+      "message": "No such accession 'ENS16232164'"
+   }
 }
 ```
 
@@ -200,6 +212,12 @@ Example: `fields=QNAME,FLAG,POS`.
 
 <table>
 <tr markdown="block"><td>
+`htsget`
+_object_
+<td>
+Container for response object.
+<table>
+<tr markdown="block"><td>
 `format`  
 _string_
 </td><td>
@@ -240,6 +258,39 @@ _optional hex string_
 MD5 digest of the blob resulting from concatenating all of the "payload" data --- the url data blocks.
 </td></tr>
 </table>
+</td></tr>
+</table>
+
+An example of a JSON response is:
+```json
+{
+   "htsget" : {
+      "format" : "BAM",
+      "urls" : [
+         {
+            "url" : "data:application/vnd.ga4gh.bam;base64,QkFNAQ=="
+         },
+         {
+            "url" : "https://htsget.blocksrv.example/sample1234/header"
+         },
+         {
+            "url" : "https://htsget.blocksrv.example/sample1234/run1.bam",
+            "headers" : {
+               "Authorization" : "Bearer xxxx",
+               "Range" : "bytes=65536-1003750"
+             }
+         },
+         {
+            "url" : "https://htsget.blocksrv.example/sample1234/run1.bam",
+            "headers" : {
+               "Authorization" : "Bearer xxxx",
+               "Range" : "bytes=2744831-9375732"
+            }
+         }
+      ]
+   }
+}
+```
 
 ## Response data blocks
 


### PR DESCRIPTION
Implements the proposal discussed in #207 to wrap the response data like this:
```
{ "htsget" : { ... } }
```

No version number is included here, but it would be trivial to add, either now or later.