### PR TITLE
Fix htsget table formatting

### DIFF
--- a/htsget.md
+++ b/htsget.md
@@ -57,7 +57,7 @@ For errors that are specific to the `htsget` protocol, the response body SHOULD 
 <tr markdown="block"><td>
 `htsget`
 _object_
-<td>
+</td><td>
 Container for response object.
 <table>
 <tr markdown="block"><td>
@@ -222,7 +222,7 @@ Example: `fields=QNAME,FLAG,POS`.
 <tr markdown="block"><td>
 `htsget`
 _object_
-<td>
+</td><td>
 Container for response object.
 <table>
 <tr markdown="block"><td>


### PR DESCRIPTION
Fix table formatting broken by 5448ce9385f48458ca2f18b4b752025465089db1, in particular the [Error Response JSON fields](http://samtools.github.io/hts-specs/htsget.html#error-response-json-fields) table.

It's recommended to preview changes beforehand, or at least to look at the rebuilt GitHub Pages web site afterwards :smile:

@mlin: I recommend merging this immediately on the basis that it is editorially obvious.