### PR TITLE
Inconsistent use of P suffix

### DIFF
--- a/VCFv4.3.tex
+++ b/VCFv4.3.tex
@@ -493,7 +493,7 @@ VCF records use a simple haplotype representation for REF and ALT alleles to des
     represented in some cases as phred-scale in a separate tag (e.g.~PL).
 
     \item The "P" suffix means "probability" as linear-scale probability in the
-    posterior distribution, which is Pr(Model$|$Data).  Examples are GP, CNP.
+    posterior distribution, which is Pr(Model$|$Data).  Examples are GP, CNP (but see DP for an exception).
 
     \item The "Q" suffix means "quality" as log-complementary-phred-scale posterior
     probability, which is -10 * log10 Pr(Data$|$Model) where the model is the most


### PR DESCRIPTION
VCF4.3 states that the suffix P means probability. However, this is not the case for DP. Wouldn't it be nice that the standard does actually follow its own recommendations (or points out to the exceptions)?
With that in mind, I have added a note pointing out the exception.