### PR TITLE
htsget: maximum block sizes for efficient buffering

### DIFF
--- a/htsget.md
+++ b/htsget.md
@@ -203,6 +203,15 @@ A comma separated list of tags to exclude, default: none.
 
 The server SHOULD respond with an `InvalidInput` error if `tags` and `notags` intersect.
 </td></tr>
+<tr markdown="block"><td>
+`maxBlockSize`  
+_optional_
+</td><td>
+The requested maximum size of returned blocks in bytes. See the 
+[maximum block sizes](#maximum-block-sizes) section for details.
+
+TODO: Add error conditions.
+</td></tr>
 </table>
 
 ### Field filtering
@@ -274,6 +283,17 @@ _optional hex string_
 </td><td>
 MD5 digest of the blob resulting from concatenating all of the "payload" data --- the url data blocks.
 </td></tr>
+
+</td></tr>
+<tr markdown="block"><td>
+`maxBlockSize`  
+_optional unsigned integer_
+</td><td>
+An upper limit on the maximum size of the data blocks in bytes. If this value is not 
+present, then client cannot assume any upper bound on the size of data blocks.
+See the [maximum block sizes](#maximum-block-sizes) section for details. 
+</td></tr>
+
 </table>
 </td></tr>
 </table>
@@ -344,6 +364,22 @@ The client obtains the data block by decoding the embedded base64 payload.
 2. client should ignore the media type (if any), treating the payload as a partial blob.
 
 Note: the base64 text should not be additionally percent encoded.
+
+### Maximum block sizes 
+
+To facilitate efficient buffering, the client MAY specify a ``maxBlockSize`` argument.
+This value is a requested maximum size for the blocks returned by the server, in bytes.
+The server treats this value as a request, but it is not obliged to comply. If the server
+does not support this feature, then it SHOULD NOT include a ``maxBlockSize`` value in
+the response. The server MAY return a ``maxBlockSize`` value that is larger than the 
+client requests. The server MUST ensure that the size of all returned blocks is less than or 
+equal to the returned ``maxBlockSize``. The returned value is an upper limit on the size 
+of the blocks, and not necessarily the maximum size of the returned blocks.
+
+The client MUST check for the presence of the ``maxBlockSize`` in the response
+and support arbitrarily large blocks if it is not included. The client MUST NOT
+assume that the requested ``maxBlockSize`` and the value returned by the server
+are the same.
 
 ### Reliability & performance considerations
 


### PR DESCRIPTION
This is an initial proposal for adding block size bounds to htsget. The idea here is for the client to suggest an upper bound on the size of the blocks that a server will return. The server then is free to either (a) ignore this and continue as before; or (b) choose some other block size upper bound that it can efficiently fulfil. This gives servers quite a bit of wiggle room in how they implement things. File-based servers should be able to support this trivially, and I'm hoping that this is sufficiently flexible that streaming servers will be able to find some upper bound fairly close to what the client requests that they can efficiently fulfil.

From a client perspective, I imagine things working as follows:

- The client sends a ``maxBlockSize`` request of 32MB (say).
- The server responds with a ``maxBlockSize`` of 64MB (say).
- The client checks the returned ``maxBlockSize``, and if it's happy to work with buffers this size, it mallocs a set of 64MB buffers and starts downloading the chunks in parallel.

The main applications for this on the client side are 
- Better error resilience through restarting failed blocks. 
- Parallel downloads 
- Approximate progress monitoring by counting the number of downloaded blocks

There are a number of details to deal with here, so this is an early version for discussion ahead of next week's call. In particular, calling both the requested and returned value ``maxBlockSize`` is  confusing, so I think we can definitely do better naming-wise.