### PR TITLE
Bam tidy up

### DIFF
--- a/SAMv1.tex
+++ b/SAMv1.tex
@@ -8,6 +8,29 @@
 \usepackage{makecell}
 \usepackage[pdfborder={0 0 0},hyperfootnotes=false]{hyperref}
 \usepackage[title]{appendix}
+\usepackage[calc]{picture}
+
+\newlength{\bytewidth}
+\newlength{\bytetotalheight}
+\newlength{\bytedepth}
+\newcommand*\byteboxsetup[1][2.1em]{\setlength{\bytewidth}{#1}
+  \settototalheight{\bytetotalheight}{MQgjpqy}
+  \settodepth{\bytedepth}{Qgjpqy}
+  \addtolength{\bytetotalheight}{8pt}\addtolength{\bytedepth}{4pt}}
+
+\newcommand*{\byteboxAux}[3]{\raisebox{-\bytedepth}
+ {\begin{picture}(#1\bytewidth,\bytetotalheight)
+    \multiput(0,0)(0,\bytetotalheight){2}{\line(1,0){#1\bytewidth}}
+    #3
+    \put(#1\bytewidth,0){\line(0,1){\bytetotalheight}}
+    \put(0,\bytedepth){\makebox[#1\bytewidth][c]{#2}}
+    \newcount\nticks \nticks #1\relax \advance\nticks -1\relax
+    \multiput(\bytewidth,0)(\bytewidth,0){\nticks}{\line(0,1){3pt}}
+  \end{picture}\strut}}
+
+% Use as e.g. \firstbytebox{2}{Tag}\bytebox{1}{\tt s}\bytebox{2}{int16\_t}
+\newcommand*{\firstbytebox}[2]{\byteboxAux{#1}{#2}{\put(0,0){\line(0,1){\bytetotalheight}}}}
+\newcommand*{\bytebox}[2]{\byteboxAux{#1}{#2}{}}
 
 \makeindex
 
@@ -921,48 +944,65 @@ For a sequence with an odd numbered length the bottom 4 bits of the last byte ar
 The case-insensitive base codes `{\tt =ACMGRSVTWYHKDBN}' are mapped to $[0,15]$ respectively with all other characters mapping to `{\tt N}' (value 15).
 
 \subsubsection{Auxiliary data encoding}\label{sec:aux-type-codes}
-Optional alignment fields are stored in BAM as a two character tag followed by a single type character and then a variable-length value.
-The type encoding is similar to SAM, apart from integer values where BAM uses the type to indicate the size in bytes of the stored value (SAM always uses {\tt i}, regardless of magnitude).
+Optional alignment fields are stored immediately after each other immediately
+following the {\sf qual} field, and are included in {\sf block\_size}.
+Each field is represented as a two-character tag followed by a single type
+character and then its value, whose length is determined by the field's type.
 
-The type codes used in BAM, and permissible values are:
+\newcommand*{\tagfield}[2]{\firstbytebox{2}{\em tag}\bytebox{1}{\tt #1}#2}
 
-\begin{center}
-\begin{tabular}{|c|l|l|}
-\hline
-{\bf Type} & {\bf Allowed values} & {\bf Description} \\
-\hline
-A & {\tt [!-\char126]} & Printable character \\
-c & -128 ... 127 & Signed 8-bit integer \\
-C & 0 ... 255 & Unsigned 8-bit integer \\
-s & -32768 ... 32767 & Signed 16-bit integer \\
-S & 0 ... 65535 & Unsigned 16-bit integer \\
-i & -2147483648 ... 2147483647 & Signed 32-bit integer \\
-I & 0 ... 4294967295 & Unsigned 32-bit integer \\
-f & Any valid IEEE 754-2008 binary32 value & Single-precision floating point \\
-Z & {\tt [\,\,\,!-\char126]*} & Printable string, terminated by NUL \\
-H & {\tt ([0-9A-F][0-9A-F])*} & Hexadecimal string (ASCII), terminated by NUL \\
-B & Depends on subtype & Numeric array, see below \\
-\hline
-\end{tabular}
+Single character `{\tt A}' fields have a total length of 4~bytes,
+with the value represented as a single byte:
+\begin{center}\small\byteboxsetup
+\tagfield{A}{\bytebox{1}{char}}
 \end{center}
 
-{\tt B} array type tags take the following form:
+While all single (i.e., non-array) integer types are stored in SAM as `{\tt i}',
+in BAM any of `{\tt cCsSiI}' may be used together with the correspondingly-sized
+binary integer value, chosen according to the field value's magnitude.
+Similarly floating point `{\tt f}' fields are represented as IEEE 754-2008
+binary32 values.
+Thus BAM numeric fields have a total length of~4, 5, or~7~bytes:
+\begin{center}\small\byteboxsetup\begin{tabular}{l@{\hspace{1in}}l}
+\tagfield{c}{\bytebox{1}{i8}} \quad (i.e., {\tt int8\_t})
+    & \tagfield{i}{\bytebox{4}{int32\_t}} \\
+\tagfield{C}{\bytebox{1}{u8}} \quad (i.e., {\tt uint8\_t})
+    & \tagfield{I}{\bytebox{4}{uint32\_t}} \\
+\tagfield{s}{\bytebox{2}{int16\_t}}
+    & \tagfield{f}{\bytebox{4}{float}} \\
+\tagfield{S}{\bytebox{2}{uint16\_t}}
+    &
+\end{tabular}\end{center}
 
-\begin{center}
-\begin{tabular}{|ll|l|}
-\hline
-{\bf Field} & & {\bf Description} \\
-\hline
-tag & & Two-character tag \\
-\hline
-{val\_type} & & Value type: {\tt B} for array tags \\
-\hline
-value & \multicolumn{1}{|l|}{sub\_type} & Array data type, matches {\tt /\char94[cCsSiIf]/}; meaning as in the table above \\\cline{2-3}
- & \multicolumn{1}{|l|}{array\_length} & 32-bit integer \\\cline{2-3}
- & \multicolumn{1}{|l|}{array\_data} & {\tt array\_length * (size of sub\_type)} bytes \\
-\hline
-\end{tabular}
-\end{center}
+\newcommand*{\byteboxvector}[2]{\bytebox{#1}{#2}\bytebox{#1}{#2}\makebox[1.5\bytewidth][c]{$\cdots$}\firstbytebox{#1}{#2}}
+
+String fields and hex-formatted byte arrays are represented as
+{\tt NUL}-terminated text strings:%
+\footnote{The BAM representation of `{\tt H}' field values as textual
+hexadecimal digits rather than binary data is for historical reasons.
+Modern applications may prefer to use `{\tt B,C}' array fields rather
+than `{\tt H}' fields.}
+\begin{center}\small\byteboxsetup\begin{tabular}{l}
+\tagfield{Z}{\byteboxvector{1}{char}\bytebox{1}{\tt NUL}} \\
+\tagfield{H}{\byteboxvector{2}{hex hex}\bytebox{1}{\tt NUL}}
+\end{tabular}\end{center}
+
+\newcommand*{\arraytagfield}[3]{\tagfield{B}{\bytebox{1}{\tt #1}\bytebox{4}{\em count}\byteboxvector{#2}{#3}}}
+
+The representation of a `{\tt B}' array field starts with a sub-type character
+similar to the numeric field types above and an {\tt int32\_t} \emph{count}
+giving the number of elements in the array.
+The array elements follow, encoded as binary integers or IEEE floats sized
+according to the sub-type:
+\begin{center}\small\byteboxsetup\begin{tabular}{l}
+\arraytagfield{c}{1}{i8} \quad (i.e., {\tt int8\_t} elements) \\
+\arraytagfield{C}{1}{u8} \quad (i.e., {\tt uint8\_t} elements) \\
+\arraytagfield{s}{2}{int16\_t} \\
+\arraytagfield{S}{2}{uint16\_t} \\
+\arraytagfield{i}{4}{int32\_t} \\
+\arraytagfield{I}{4}{uint32\_t} \\
+\arraytagfield{f}{4}{float}
+\end{tabular}\end{center}
 
 \pagebreak
 

--- a/SAMv1.tex
+++ b/SAMv1.tex
@@ -959,7 +959,9 @@ with the value represented as a single byte:
 
 While all single (i.e., non-array) integer types are stored in SAM as `{\tt i}',
 in BAM any of `{\tt cCsSiI}' may be used together with the correspondingly-sized
-binary integer value, chosen according to the field value's magnitude.
+binary integer value, chosen according to the field value's magnitude.%
+\footnote{The signedness and size used for each integer value is an
+implementation choice, but is typically the smallest that suffices.}
 Similarly floating point `{\tt f}' fields are represented as IEEE 754-2008
 binary32 values.
 Thus BAM numeric fields have a total length of~4, 5, or~7~bytes:

--- a/SAMv1.tex
+++ b/SAMv1.tex
@@ -867,7 +867,7 @@ underlined word in uppercase denotes a field in the SAM format.
   & \multicolumn{2}{l|}{\sf l\_read\_name} & Length of {\sf read\_name} below ($={\sf length}(\underline{\sf QNAME})+1$). & {\tt uint8\_t} & \\\cline{2-6}
   & \multicolumn{2}{l|}{\sf mapq} & Mapping quality (=\underline{\sf MAPQ}). & {\tt uint8\_t} & \\\cline{2-6}
   & \multicolumn{2}{l|}{\sf bin} & BAI index bin, see Section~\ref{sec:bin-field}  & {\tt uint16\_t} & \\\cline{2-6}
-  & \multicolumn{2}{l|}{\sf n\_cigar\_op} & Number of operations in \underline{\sf CIGAR}. & {\tt uint16\_t} & \\\cline{2-6}
+  & \multicolumn{2}{l|}{\sf n\_cigar\_op} & Number of operations in \underline{\sf CIGAR}, see Section~\ref{sec:ncigar} & {\tt uint16\_t} & \\\cline{2-6}
   & \multicolumn{2}{l|}{\sf flag} & Bitwise flags (= \underline{\sf FLAG})\footnotemark\ & {\tt uint16\_t} & \\\cline{2-6}
   & \multicolumn{2}{l|}{\sf l\_seq} & Length of \underline{\sf SEQ} & {\tt int32\_t} & \\\cline{2-6}
   & \multicolumn{2}{l|}{\sf next\_refID} & Ref-ID of the next segment ($-1\le{\sf mate\_refID}<{\sf n\_ref}$) & {\tt int32\_t} & [-1] \\\cline{2-6}
@@ -875,7 +875,7 @@ underlined word in uppercase denotes a field in the SAM format.
   & \multicolumn{2}{l|}{\sf tlen} & Template length ($=\underline{\sf TLEN}$) & {\tt int32\_t} & [0] \\\cline{2-6}
   & \multicolumn{2}{l|}{\sf read\_name} & Read name,\footnotemark\ {\tt NUL}-terminated (\underline{\sf QNAME} plus a trailing `{\tt \char92 0}') & {\tt char[{\sf l\_read\_name}]} & \\\cline{2-6}
   & \multicolumn{2}{l|}{\sf cigar} & CIGAR: {\tt {\sf op\_len}\char60\char60 4\char124{\sf op}}. `{\tt MIDNSHP\char61X}'$\to$`012345678' & {\tt uint32\_t[{\sf n\_cigar\_op}]} & \\\cline{2-6}
-  & \multicolumn{2}{l|}{\sf seq} & 4-bit encoded read: `{\tt =ACMGRSVTWYHKDBN}'$\to[0,15]$; other characters mapped to `{\tt N}'; high nybble first (1st base in the highest 4-bit of the 1st byte) & {\tt uint8\_t[({\sf l\_seq}+1)/2]} & \\\cline{2-6}
+  & \multicolumn{2}{l|}{\sf seq} & 4-bit encoded read: `{\tt =ACMGRSVTWYHKDBN}'$\to[0,15]$. See Section~\ref{sec:seq} & {\tt uint8\_t[({\sf l\_seq}+1)/2]} & \\\cline{2-6}
   & \multicolumn{2}{l|}{\sf qual} & Phred base quality (a sequence of {\tt 0xFF} if absent) & {\tt char[{\sf l\_seq}]} & \\\cline{2-6}
   & \multicolumn{5}{c|}{\textcolor{gray}{\it List of auxiliary data (until the end of the alignment block)}} \\\cline{3-6}
   & & {\sf tag} & Two-character tag & {\tt char[2]} & \\\cline{3-6}
@@ -888,20 +888,7 @@ underlined word in uppercase denotes a field in the SAM format.
 \footnotetext{As noted in Section~\ref{sec:alnrecord}, reserved {\sf FLAG} bits
 should be written as zero and ignored on reading by current software.}
 \stepcounter{footnote}
-\footnotetext{With 16 bits, {\sf n\_cigar\_op} can keep at most 65535 CIGAR
-operations in BAM files. For an alignment with more CIGAR operations, BAM
-stores the real {\sf CIGAR}, encoded the same way as the {\sf cigar} field in
-BAM, in the {\tt CG} optional tag of type `{\tt B,I}', and sets {\sf CIGAR} to
-`{\tt kSmN}' as a placeholder, where `{\tt k}' equals {\sf l\_seq}, `{\tt m}'
-is the reference sequence length in the alignment, and `{\tt S}' and `{\tt N}'
-are the soft-clipping and reference-clip CIGAR operators, respectively -- i.e.
-in the binary form, {\sf n\_cigar\_op}=2 and {\sf cigar}={\tt [k\char60\char60
-4\char124{4},m\char60\char60 4\char124{3}]}. If tag {\tt CG} is present and
-the first CIGAR operation clips the entire read, a BAM parsing library is
-expected to update {\sf n\_cigar\_op} and {\sf cigar} with the real CIGAR
-stored in the {\tt CG} tag and remove the now-redundant {\tt CG} tag.}
-\stepcounter{footnote}
-\footnotetext{For backward compatibility, a {\sf QNAME} `{\tt *}' is stored as a C string {\tt "*\char92 0"}.}
+\footnotetext{For backward compatibility, an absent {\sf QNAME} (represented as `{\tt *}' in SAM) is stored as a C string {\tt "*\char92 0"}.}
 
 \subsubsection{BIN field calculation}\label{sec:bin-field}
 {\sf BIN} is calculated using the {\sf reg2bin()} function in
@@ -913,6 +900,25 @@ Section~\ref{sec:recommended-practice}) the alignment is treated as
 being length one.
 Note unmapped reads with {\sf POS} $0$ (which becomes $-1$ in BAM) therefore
 use {\sf reg2bin(-1, 0)} which is $4680$.
+
+\subsubsection{N\_CIGAR\_OP field}\label{sec:ncigar}
+With 16 bits, {\sf n\_cigar\_op} can keep at most 65535 CIGAR
+operations in BAM files. For an alignment with more CIGAR operations, BAM
+stores the real {\sf CIGAR}, encoded the same way as the {\sf cigar} field in
+BAM, in the {\tt CG} optional tag of type `{\tt B,I}', and sets {\sf CIGAR} to
+`\textit{k}{\tt S}\textit{m}{\tt N}' as a placeholder, where `\textit{k}' equals {\sf l\_seq}, `\textit{m}'
+is the reference sequence length in the alignment, and `{\tt S}' and `{\tt N}'
+are the soft-clipping and reference-clip CIGAR operators, respectively -- i.e.
+in the binary form, {\sf n\_cigar\_op}=2 and {\sf cigar}={\tt [\textit{k}\char60\char60
+4\char124{4},\textit{m}\char60\char60 4\char124{3}]}. If tag {\tt CG} is present and
+the first CIGAR operation clips the entire read, a BAM parsing library is
+expected to update {\sf n\_cigar\_op} and {\sf cigar} with the real CIGAR
+stored in the {\tt CG} tag and remove the now-redundant {\tt CG} tag.
+
+\subsubsection{SEQ encoding}\label{sec:seq}
+Sequence is encoded in 4-bit values, with adjacent bases packed into the same byte starting with the highest 4 bits first.
+For a sequence with an odd numbered length the bottom 4 bits of the last byte are undefined, but we recommend writing these as zero.
+The case-insensitive base codes `{\tt =ACMGRSVTWYHKDBN}' are mapped to $[0,15]$ respectively with all other characters mapping to `{\tt N}' (value 15).
 
 \subsubsection{Auxiliary data encoding}\label{sec:aux-type-codes}
 Optional alignment fields are stored in BAM as a two character tag followed by a single type character and then a variable-length value.
@@ -1171,6 +1177,7 @@ specification with its own version numbering.\footnote{
 
 \begin{itemize}
 \item Permit UTF-8 in a few header tags. (Mar 2018)
+\item Add support for $>65535$ cigar operations. (Jul 2017)
 \item Add {\tt @SQ AH} header tag. (Mar 2017)
 \item Auxiliary tags migrated to SAMtags document. (Sep 2016)
 \item Z and H auxiliary tags are permitted to be zero length. (Jun 2016)

--- a/SAMv1.tex
+++ b/SAMv1.tex
@@ -511,7 +511,7 @@ explicitly limited in SAM.  However, BAM can represent values in the
 range~$[-2^{31},2^{32})$, so in practice this is the realistic range
 of values for SAM's `{\tt i}' as well.}
 \stepcounter{footnote}
-\footnotetext{For example, a byte array $[{\tt 0x1a},{\tt 0xe3},{\tt 0x1}]$ corresponds to a Hex string `{\tt 1AE301}'.}
+\footnotetext{For example, the six-character Hex string `{\tt 1AE301}' represents the byte array $[{\tt 0x1a},{\tt 0xe3},{\tt 0x1}]$.}
 \end{center}
 For an integer or numeric array (type `{\tt B}'), the first letter indicates the type of numbers
 in the following comma separated array. The letter can be one of `{\tt cCsSiIf}', corresponding to
@@ -940,7 +940,7 @@ i & -2147483648 ... 2147483647 & Signed 32-bit integer \\
 I & 0 ... 4294967295 & Unsigned 32-bit integer \\
 f & Any valid IEEE 754-2008 binary32 value & Single-precision floating point \\
 Z & {\tt [\,\,\,!-\char126]*} & Printable string, terminated by NUL \\
-H & {\tt ([0-9A-F][0-9A-F])*} & Hexadecimal string, terminated by NUL \\
+H & {\tt ([0-9A-F][0-9A-F])*} & Hexadecimal string (ASCII), terminated by NUL \\
 B & Depends on subtype & Numeric array, see below \\
 \hline
 \end{tabular}

--- a/SAMv1.tex
+++ b/SAMv1.tex
@@ -861,7 +861,7 @@ underlined word in uppercase denotes a field in the SAM format.
   & \multicolumn{2}{l|}{\sf name} & Reference sequence name; {\tt NUL}-terminated & {\tt char[{\sf l\_name}]} & \\\cline{2-6}
   & \multicolumn{2}{l|}{\sf l\_ref} & Length of the reference sequence & {\tt int32\_t} & \\\cline{1-6}
   \multicolumn{6}{|c|}{\textcolor{gray}{\it List of alignments (until the end of the file)}} \\\cline{2-6}
-  & \multicolumn{2}{l|}{\sf block\_size} & Length of the remainder of the alignment record & {\tt int32\_t} & \\\cline{2-6}
+  & \multicolumn{2}{l|}{\sf block\_size} & Total length of the alignment record, excluding this field & {\tt int32\_t} & \\\cline{2-6}
   & \multicolumn{2}{l|}{\sf refID} & Reference sequence ID, $-1\leq{\sf refID}<{\sf n\_ref}$; -1 for a read without a mapping position. & {\tt int32\_t} & [-1] \\\cline{2-6}
   & \multicolumn{2}{l|}{\sf pos} & 0-based leftmost coordinate ($=\underline{\sf POS}-1$)& {\tt int32\_t} & [-1]\\\cline{2-6}
   & \multicolumn{2}{l|}{\sf l\_read\_name} & Length of {\sf read\_name} below ($={\sf length}(\underline{\sf QNAME})+1$). & {\tt uint8\_t} & \\\cline{2-6}

--- a/SAMv1.tex
+++ b/SAMv1.tex
@@ -864,8 +864,11 @@ underlined word in uppercase denotes a field in the SAM format.
   & \multicolumn{2}{l|}{\sf block\_size} & Length of the remainder of the alignment record & {\tt int32\_t} & \\\cline{2-6}
   & \multicolumn{2}{l|}{\sf refID} & Reference sequence ID, $-1\leq{\sf refID}<{\sf n\_ref}$; -1 for a read without a mapping position. & {\tt int32\_t} & [-1] \\\cline{2-6}
   & \multicolumn{2}{l|}{\sf pos} & 0-based leftmost coordinate ($=\underline{\sf POS}-1$)& {\tt int32\_t} & [-1]\\\cline{2-6}
-  & \multicolumn{2}{l|}{\sf bin\_mq\_nl} & {\tt{\sf bin}\char60\char60 16\char124\underline{\sf MAPQ}\char60\char60 8\char124{\sf l\_read\_name}}; {\sf bin} is computed from the mapping position;\footnotemark\ {\sf l\_read\_name} is the length of {\sf read\_name} below ($={\sf length}(\underline{\sf QNAME})+1$). & {\tt uint32\_t} & \\\cline{2-6}
-  & \multicolumn{2}{l|}{\sf flag\_nc} & {\tt \underline{\sf FLAG}\char60\char60 16\char124{\sf n\_cigar\_op}};\footnotemark\ {\sf n\_cigar\_op} is the number of operations in \underline{\sf CIGAR}\footnotemark. & {\tt uint32\_t} & \\\cline{2-6}
+  & \multicolumn{2}{l|}{\sf l\_read\_name} & Length of {\sf read\_name} below ($={\sf length}(\underline{\sf QNAME})+1$). & {\tt uint8\_t} & \\\cline{2-6}
+  & \multicolumn{2}{l|}{\sf mapq} & Mapping quality (=\underline{\sf MAPQ}). & {\tt uint8\_t} & \\\cline{2-6}
+  & \multicolumn{2}{l|}{\sf bin} & BAI index bin, see Section~\ref{sec:bin-field}  & {\tt uint16\_t} & \\\cline{2-6}
+  & \multicolumn{2}{l|}{\sf n\_cigar\_op} & Number of operations in \underline{\sf CIGAR}. & {\tt uint16\_t} & \\\cline{2-6}
+  & \multicolumn{2}{l|}{\sf flag} & Bitwise flags (= \underline{\sf FLAG})\footnotemark\ & {\tt uint16\_t} & \\\cline{2-6}
   & \multicolumn{2}{l|}{\sf l\_seq} & Length of \underline{\sf SEQ} & {\tt int32\_t} & \\\cline{2-6}
   & \multicolumn{2}{l|}{\sf next\_refID} & Ref-ID of the next segment ($-1\le{\sf mate\_refID}<{\sf n\_ref}$) & {\tt int32\_t} & [-1] \\\cline{2-6}
   & \multicolumn{2}{l|}{\sf next\_pos} & 0-based leftmost pos of the next segment ($=\underline{\sf PNEXT}-1$) & {\tt int32\_t} & [-1] \\\cline{2-6}
@@ -876,22 +879,12 @@ underlined word in uppercase denotes a field in the SAM format.
   & \multicolumn{2}{l|}{\sf qual} & Phred base quality (a sequence of {\tt 0xFF} if absent) & {\tt char[{\sf l\_seq}]} & \\\cline{2-6}
   & \multicolumn{5}{c|}{\textcolor{gray}{\it List of auxiliary data (until the end of the alignment block)}} \\\cline{3-6}
   & & {\sf tag} & Two-character tag & {\tt char[2]} & \\\cline{3-6}
-  & & {\sf val\_type} & Value type: {\tt AcCsSiIfZHB}\footnotemark$^,$\footnotemark & {\tt char} & \\\cline{3-6}
+  & & {\sf val\_type} & Value type: {\tt AcCsSiIfZHB}, see Section~\ref{sec:aux-type-codes} & {\tt char} & \\\cline{3-6}
   & & {\sf value} & Tag value & (by {\sf val\_type}) &\\
   \cline{1-6}
 \end{tabular}}
 \end{table}
-\addtocounter{footnote}{-5}
-\footnotetext{{\sf BIN} is calculated using the {\sf reg2bin()} function
-in Section~\ref{sec:code}. For mapped reads this uses {\sf POS-1}
-(i.e.,~0-based left position) and the alignment end point using the
-alignment length from the {\sf CIGAR} string. For unmapped reads
-(e.g.,~paired end reads where only one part is mapped, see
-Section~\ref{sec:recommended-practice}) treat the alignment as
-being length one. Note unmapped reads with {\sf POS} $0$ (which
-becomes $-1$ in BAM) therefore use {\sf reg2bin(-1, 0)} which
-is $4680$.}
-\stepcounter{footnote}
+\addtocounter{footnote}{-1}
 \footnotetext{As noted in Section~\ref{sec:alnrecord}, reserved {\sf FLAG} bits
 should be written as zero and ignored on reading by current software.}
 \stepcounter{footnote}
@@ -909,16 +902,61 @@ expected to update {\sf n\_cigar\_op} and {\sf cigar} with the real CIGAR
 stored in the {\tt CG} tag and remove the now-redundant {\tt CG} tag.}
 \stepcounter{footnote}
 \footnotetext{For backward compatibility, a {\sf QNAME} `{\tt *}' is stored as a C string {\tt "*\char92 0"}.}
-\stepcounter{footnote}
-\footnotetext{An integer may be stored as one of `{\tt cCsSiI}' in BAM, representing {\tt int8\_t}, {\tt uint8\_t},
-{\tt int16\_t}, {\tt uint16\_t}, {\tt int32\_t} and {\tt uint32\_t}, respectively.
-In SAM, all single (i.e., non-array) integer types are stored as `{\tt i}', regardless of magnitude.}
-\stepcounter{footnote}
-\footnotetext{A `{\tt B}'-typed (array) tag--value pair is stored as follows. The first two bytes keep the two-character tag. The 3rd byte is always `{\tt B}'.
-	The 4th byte, matching {\tt /\char94[cCsSiIf]\$/}, indicates the type of an element in the array.
-	Bytes from 5 to 8 encode a little-endian 32-bit integer which gives the number of elements in the array.
-	Bytes starting from the 9th store the array in the little-endian byte order; the number of these
-	bytes is determined by the type and the length of the array.}
+
+\subsubsection{BIN field calculation}\label{sec:bin-field}
+{\sf BIN} is calculated using the {\sf reg2bin()} function in
+Section~\ref{sec:code}.
+For mapped reads this uses {\sf POS-1} (i.e.,~0-based left position) and the
+alignment end point using the alignment length from the {\sf CIGAR} string.
+For unmapped reads (e.g.,~paired end reads where only one part is mapped, see
+Section~\ref{sec:recommended-practice}) the alignment is treated as
+being length one.
+Note unmapped reads with {\sf POS} $0$ (which becomes $-1$ in BAM) therefore
+use {\sf reg2bin(-1, 0)} which is $4680$.
+
+\subsubsection{Auxiliary data encoding}\label{sec:aux-type-codes}
+Optional alignment fields are stored in BAM as a two character tag followed by a single type character and then a variable-length value.
+The type encoding is similar to SAM, apart from integer values where BAM uses the type to indicate the size in bytes of the stored value (SAM always uses {\tt i}, regardless of magnitude).
+
+The type codes used in BAM, and permissible values are:
+
+\begin{center}
+\begin{tabular}{|c|l|l|}
+\hline
+{\bf Type} & {\bf Allowed values} & {\bf Description} \\
+\hline
+A & {\tt [!-\char126]} & Printable character \\
+c & -128 ... 127 & Signed 8-bit integer \\
+C & 0 ... 255 & Unsigned 8-bit integer \\
+s & -32768 ... 32767 & Signed 16-bit integer \\
+S & 0 ... 65535 & Unsigned 16-bit integer \\
+i & -2147483648 ... 2147483647 & Signed 32-bit integer \\
+I & 0 ... 4294967295 & Unsigned 32-bit integer \\
+f & Any valid IEEE 754-2008 binary32 value & Single-precision floating point \\
+Z & {\tt [\,\,\,!-\char126]*} & Printable string, terminated by NUL \\
+H & {\tt ([0-9A-F][0-9A-F])*} & Hexadecimal string, terminated by NUL \\
+B & Depends on subtype & Numeric array, see below \\
+\hline
+\end{tabular}
+\end{center}
+
+{\tt B} array type tags take the following form:
+
+\begin{center}
+\begin{tabular}{|ll|l|}
+\hline
+{\bf Field} & & {\bf Description} \\
+\hline
+tag & & Two-character tag \\
+\hline
+{val\_type} & & Value type: {\tt B} for array tags \\
+\hline
+value & \multicolumn{1}{|l|}{sub\_type} & Array data type, matches {\tt /\char94[cCsSiIf]/}; meaning as in the table above \\\cline{2-3}
+ & \multicolumn{1}{|l|}{array\_length} & 32-bit integer \\\cline{2-3}
+ & \multicolumn{1}{|l|}{array\_data} & {\tt array\_length * (size of sub\_type)} bytes \\
+\hline
+\end{tabular}
+\end{center}
 
 \pagebreak
 


### PR DESCRIPTION
This incorporates the first commit from @daviesrob's BAMv2 PR to tidy up the BAM table, moving excessive footnotes into their own sections.  This coincidentally also fixes #273.

I then applied the same tidying logic to the new footnote on >65535 cigar operations and added clarification of the ordering in which sequence bases are encoded (fixes #269).

Finally, updated the version history as we forgot to do this when merging the long-cigar fix.