### PR TITLE
changing VCF maintainer in MAINTAINERS.md

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -21,10 +21,10 @@ Past SAM/BAM maintainers include Jay Carey, Tim Fennell, and Nils Homer.
 ### VCF/BCF
 
 * Cristina Yenyxe Gonzalez Garcia (@cyenyxe)
-* David Roazen (@droazen)
+* Louis Bergelson (@lbergelson)
 * Petr Danecek (@pd3)
 
-Past VCF/BCF maintainers include Ryan Poplin.
+Past VCF/BCF maintainers include Ryan Poplin and David Roazen.
 
 ### Htsget
 


### PR DESCRIPTION
Louis Bergelson (me) is replacing David Roazen as the Broad's VCF maintainer