### PR TITLE
Definition of SB INFO field Number and Type

### DIFF
--- a/VCFv4.3.tex
+++ b/VCFv4.3.tex
@@ -354,7 +354,7 @@ There are 8 fixed fields per record.  Fixed fields are:
 	MQ		& 1		& .		& RMS mapping quality \\
 	MQ0   		& 1		& Integer	& Number of MAPQ == 0 reads \\
 	NS		& 1		& Integer	& Number of samples with data \\
-	SB		& .		& .		& Strand bias \\
+	SB		& 4		& Integer	& Strand bias \\
 	SOMATIC		& 0		& Flag		& Somatic mutation (for cancer genomics) \\
 	VALIDATED	& 0		& Flag		& Validated by follow-up experiment \\
 	1000G		& 0		& Flag		& 1000 Genomes membership \\


### PR DESCRIPTION
SB INFO field defined as Number=4, Type=Integer.

Fixes #189 