### PR TITLE
SAM SA tag: make rname and strand requirements explicit.

### DIFF
--- a/SAMtags.tex
+++ b/SAMtags.tex
@@ -207,6 +207,7 @@ for any associated quality values.
 Other canonical alignments in a chimeric alignment, formatted as a semicolon-delimited list.
 Each element in the list represents a part of the chimeric alignment. Conventionally, at a supplementary line, the first element points to the primary line.
 \emph{Strand} is either `{\tt +}' or `{\tt -}', indicating positive/negative strand, corresponding to FLAG bit 0x10.
+\emph{Pos} is a 1-based coordinate.
 
 \item[SM:i:\tagvalue{}]
 Template-independent mapping quality.
@@ -301,7 +302,7 @@ Deprecated alternative to {\tt BC} tag originally used at Sanger.
 Original CIGAR, usually before realignment.
 
 \item[OP:i:\tagvalue{pos}]
-Original mapping position, usually before realignment.
+Original 1-based mapping position, usually before realignment.
 
 \item[OQ:Z:\tagvalue{qualities}]
 Original base quality, usually before recalibration.

--- a/SAMtags.tex
+++ b/SAMtags.tex
@@ -206,6 +206,7 @@ for any associated quality values.
 \item[SA:Z:\tagregex{{\tt (}\emph{rname}{\tt ,}\emph{pos}{\tt ,}\emph{strand}{\tt ,}\emph{CIGAR}{\tt ,}\emph{mapQ}{\tt ,}\emph{NM}{\tt ;)}+}]
 Other canonical alignments in a chimeric alignment, formatted as a semicolon-delimited list.
 Each element in the list represents a part of the chimeric alignment. Conventionally, at a supplementary line, the first element points to the primary line.
+\emph{Strand} is either `{\tt +}' or `{\tt -}', indicating positive/negative strand, corresponding to FLAG bit 0x10.
 
 \item[SM:i:\tagvalue{}]
 Template-independent mapping quality.

--- a/SAMv1.tex
+++ b/SAMv1.tex
@@ -487,7 +487,7 @@ Each bit is explained in the following table:
   next read.  If {\sf
     RNEXT} is `*', no assumptions can be made on {\sf PNEXT} and bit
   0x20.
-\item {\sf PNEXT}: Position of the primary alignment of the NEXT read in the template. Set as
+\item {\sf PNEXT}: 1-based Position of the primary alignment of the NEXT read in the template. Set as
   0 when the information is unavailable. This field equals {\sf POS} at the primary line of
   the next read. If {\sf PNEXT} is 0, no assumptions can be made on
   {\sf RNEXT} and bit 0x20.


### PR DESCRIPTION
Clarified SA tag following discussions on the OA tag PR https://github.com/samtools/hts-specs/pull/193