### PR TITLE
Bug fix NP encoding type.

### DIFF
--- a/CRAMv2.1.tex
+++ b/CRAMv2.1.tex
@@ -1105,7 +1105,7 @@ is included into the CRAM record:
 \hline
 3 & int & NS & mate reference sequence identifier \tabularnewline
 \hline
-4 & long & NP & mate alignment start position \tabularnewline
+4 & int & NP & mate alignment start position \tabularnewline
 \hline
 5 & int & TS & the size of the template (insert size)\tabularnewline
 \hline

--- a/CRAMv3.tex
+++ b/CRAMv3.tex
@@ -1170,7 +1170,7 @@ is included into the CRAM record:
 \hline
 3 & int & NS & mate reference sequence identifier \tabularnewline
 \hline
-4 & long & NP & mate alignment start position \tabularnewline
+4 & int & NP & mate alignment start position \tabularnewline
 \hline
 5 & int & TS & the size of the template (insert size)\tabularnewline
 \hline


### PR DESCRIPTION
It is defined as 'int' in the main table, but section 1.5 lists the encoding type as long.  This is both pointless (the mate's AP field is int, not long) and also not how it is implemented in both htsjdk and htslib.  The origin of this stems all the way back to the CRAM 1.0 word document, but was apparently missed when fixing the spec to match the initial Java implementation.

Many of those inconsistencies were fixed, leading to CRAM v2.0 as the initial joint C/Java definition, but this is sadly something that wasn't spotted at the time.

Java code using \<Integer\>: https://github.com/samtools/htsjdk/blob/master/src/main/java/htsjdk/samtools/cram/encoding/reader/AbstractReader.java#L53-L54

C code using E_INT: https://github.com/samtools/htslib/blob/develop/cram/cram_encode.c#L1487-L1489.

