### PR TITLE
Bump version to VN:1.6 due to long CIGAR strings

### DIFF
--- a/SAMtags.tex
+++ b/SAMtags.tex
@@ -424,7 +424,11 @@ Cellular barcode tags CB, CR, and CY added.
 
 \subsubsection*{November 2017}
 
-CG tag added.
+SAM version number {\tt VN:1.6} introduced, indicating the addition of the CG tag representation of very long CIGAR strings.
+Files that contain records with more than 65,535 CIGAR operators should not declare a version number lower than~1.6 in their {\tt @HD} headers.
+% Technically only BAM files containing records with CG tags need to avoid
+% declaring VN<1.6, but recommending that SAM and CRAM files with long CIGAR
+% strings also declare VN:1.6+ aids file format conversion.
 
 \subsubsection*{August 2017}
 

--- a/SAMv1.tex
+++ b/SAMv1.tex
@@ -59,7 +59,7 @@ not. Each alignment line has 11 mandatory fields for essential alignment
 information such as mapping position, and variable number of optional
 fields for flexible or aligner specific information.
 
-This specification is for version 1.5 of the SAM and BAM formats.  Each SAM and
+This specification is for version 1.6 of the SAM and BAM formats.  Each SAM and
 BAM file may optionally specify the version being used via the
 {\tt @HD VN} tag. For full version history see Appendix~\ref{sec:history}. 
 
@@ -95,7 +95,7 @@ properly aligned\slash multiple segments;
 properly aligned\slash multiple segments.}
 \begin{framed}\small
 \begin{verbatim}
-@HD VN:1.5 SO:coordinate
+@HD VN:1.6 SO:coordinate
 @SQ SN:ref LN:45
 r001   99 ref  7 30 8M2I4M1D3M = 37  39 TTAGATAAAGGATACTG *
 r002    0 ref  9 30 3S6M1P1I4M *  0   0 AAAAGATAAGGATA    *
@@ -707,7 +707,7 @@ three alignments are all shifted by 2. {\sf CIGAR} of alignments bridging the
 
 \begin{framed}\small
 \begin{verbatim}
-@HD VN:1.5 SO:coordinate
+@HD VN:1.6 SO:coordinate
 @SQ SN:ref LN:47
 ref   516 ref  1  0 14M2D31M   *  0   0 AGCATGTTAGATAAGATAGCTGTGCTAGTAGGCAGTCAGCGCCAT *
 r001   99 ref  7 30 14M1D3M    = 39  41 TTAGATAAAGGATACTG *
@@ -1220,12 +1220,17 @@ separate {\sl Sequence Alignment/Map Optional Fields Specification}.%
 \href{http://samtools.github.io/hts-specs/SAMtags.pdf}{\tt SAMtags.pdf}
 at \url{https://github.com/samtools/hts-specs}.}
 
-\subsection*{1.5: 23 May 2013 to current}
+\subsection*{1.6: 28 November 2017 to current}
 
 \begin{itemize}
 \item Add {\tt @RG BC} header tag. (Apr 2018)
 \item Permit UTF-8 in a few header tags. (Mar 2018)
-\item Add support for $>65535$ cigar operations. (Jul 2017)
+\item\textbf{Add support for CIGAR strings with more than 65,535 operations.} (Nov 2017)
+\end{itemize}
+
+\subsection*{1.5: 23 May 2013 to November 2017}
+
+\begin{itemize}
 \item Add {\tt @SQ AH} header tag. (Mar 2017)
 \item Auxiliary tags migrated to SAMtags document. (Sep 2016)
 \item Z and H auxiliary tags are permitted to be zero length. (Jun 2016)


### PR DESCRIPTION
PR #227 was merged as dab57f44a4d5358e53d9f75a7d6c6ab2924451b3 on 28 November 2017, but the [discussion about bumping the version number](https://github.com/samtools/hts-specs/pull/227#issuecomment-342091422) to indicate the presence of this feature was never returned to:

> [@jkbonfield]
> I'm tempted however to suggest that we ought to bump the SAM version number, even though this is technically a BAM only change. Why? Because there is no BAM version number other than the sledgehammer complete format change and there is the risk that this BAM only change will leak into SAM anyway, hence having a fixed version where we know it can occur (or vice versa, where we know it cannot) acts in a similar way to CG header tag, but more useful IMO. Plus, like it or not, the BAM and SAM formats have been inextricably linked in the same document since day 1.

The SAM version number was bumped to 1.4 to signal the existence of B arrays; to 1.5 to signal the existence of the SUPPLEMENTARY flag bit. IMHO this new CIGAR representation warrants the same treatment: the new tag field will be unnoticed by older code, which will see the placeholder
CIGAR string — so it needs to be possible to signal the presence of CG tags via the `@HD-VN` version number header field.