### PR TITLE
Add full SAMtags chronological history

### DIFF
--- a/SAMtags.tex
+++ b/SAMtags.tex
@@ -411,17 +411,111 @@ to \mailtourl{samtools-devel@lists.sourceforge.net}.
 
 \begin{appendices}
 \appendix
-\section{SAM Tags History}\label{sec:history}
+\section{Tag History}
 
-This lists the date of each tagged SAM version along with changes that
-have been made while that version was current.  
+This appendix lists when standard tags were initially defined or significantly changed, and other historical events that affect how tags are interpreted or what files they may appear in.
 
-\subsection*{1.5: 23 May 2013 to current}
-\begin{itemize}
-\item Cellular barcode tags CB, CR, and CY added. (May 2018)
-\item Add UMI-related tags (RX, QX, OX, BZ, MI) and clarified usage of sample barcode tag BC. (August 2017)
-\item SAMtags.txt (this file) created with tags from SAMv1 
-\end{itemize}
+\setlength{\parindent}{0pt}
+\newcommand*{\gap}{\vspace*{2ex}}
+
+\subsubsection*{May 2018}
+
+Cellular barcode tags CB, CR, and CY added.
+
+\subsubsection*{November 2017}
+
+CG tag added.
+
+\subsubsection*{August 2017}
+
+Unique molecular identifier tags BZ, MI, OX, QX, and RX added.
+
+Usage of sample barcode tag BC clarified.
+
+\subsubsection*{June 2017}
+
+Corrected the description of the E2 tag, which previously wrongly claimed E2 to be encoded as per {\sf QUAL}.
+
+\subsubsection*{September 2016}
+
+Predefined tags, previously listed as a brief table within the main SAM specification, have been split out into this new document.
+There is now space for clearer and more complete tag descriptions.
+
+\subsubsection*{February 2014}
+
+MC tag added.
+
+\subsubsection*{May 2013}
+
+SAM version number {\tt VN:1.5} introduced, indicating the addition of the {\sc supplementary} flag (bit 0x800).
+
+SA tag added.
+
+\subsubsection*{March 2012}
+
+Descriptions of CT and PT annotation tags significantly clarified.
+
+\subsubsection*{October 2011}
+
+Sample barcode tags QT and RT added, with RT being identified as a deprecated alternative to BC.
+
+% These were actually added in late September as RT/PT, but RT was changed to
+% CT (see samtools-devel, "Potential clash of RT tags (annotation vs barcode)",
+% October 2011) before read-annotation-RT appeared in the wild.
+Read annotation tags CT and PT added.
+
+\subsubsection*{September 2011}
+
+% This was actually August 29th, but let's call it September.
+FZ tag's type changed from {\tt H} to {\tt B,S}-array.
+
+BC and CO tags added.
+
+\subsubsection*{April 2011}
+
+SAM version number {\tt VN:1.4} introduced, indicating the addition of the {\tt B}-array tag type.
+Files that contain records with {\tt B}-array fields should not declare a version number lower than~1.4 in their {\tt @HD} headers.
+
+\gap
+FZ tag added, with type {\tt H}.
+
+MD tag description changed to allow IUPAC ambiguity codes in addition to {\tt ACGTN}.
+
+\subsubsection*{March 2011}
+
+CC and CP tags reinstated with their original meanings.
+
+\subsubsection*{November 2010}
+
+BQ tag added.
+
+\subsubsection*{July 2010}
+
+The specification was rewritten as a \LaTeX\ document specifying SAM version number {\tt VN:1.3}.
+
+\gap
+Tags FI, FS, OC, OP, OQ, and TC added.
+
+Tags GC, GQ, and GS added and reserved for backwards compatibility.
+
+Existing CC, CP, and MF tags noted as reserved for backwards compatibility.
+
+\subsubsection*{July 2009}
+
+The original SAM ``0.1.2-draft'' specification specified version number {\tt VN:1.0} and defined a total of thirty standard tags:
+
+\begin{center}
+\begin{tabular}{l@{\qquad}l@{\qquad}l@{\qquad}l@{\qquad}l}
+AM & CS & IH & NM & RG \\
+AS & E2 & LB & PG & S2 \\
+CC & H0 & MD & PQ & SM \\
+CM & H1 & MF & PU & SQ \\
+CP & H2 & MQ & Q2 & U2 \\
+CQ & HI & NH & R2 & UQ
+\end{tabular}
+\end{center}
+
+At this time, SQ and S2 were already deprecated in favour of E2 and U2.
 
 \end{appendices}
 

--- a/SAMtags.tex
+++ b/SAMtags.tex
@@ -434,7 +434,7 @@ Usage of sample barcode tag BC clarified.
 
 \subsubsection*{June 2017}
 
-Corrected the description of the E2 tag, which previously wrongly claimed E2 to be encoded as per {\sf QUAL}.
+Corrected the description of the E2 (second-most-likely bases) tag, which was previously unclear as to whether it contains bases or base qualities.
 
 \subsubsection*{September 2016}
 
@@ -447,7 +447,7 @@ MC tag added.
 
 \subsubsection*{May 2013}
 
-SAM version number {\tt VN:1.5} introduced, indicating the addition of the {\sc supplementary} flag (bit 0x800).
+SAM version number {\tt VN:1.5} introduced, with limited impact for tags other than indicating that the CT/PT annotation tag definitions are considered finalised.
 
 SA tag added.
 
@@ -496,9 +496,9 @@ The specification was rewritten as a \LaTeX\ document specifying SAM version num
 \gap
 Tags FI, FS, OC, OP, OQ, and TC added.
 
-Tags GC, GQ, and GS added and reserved for backwards compatibility.
+Tags GC, GQ, and GS listed as reserved for backwards compatibility.
 
-Existing CC, CP, and MF tags noted as reserved for backwards compatibility.
+Existing CC, CP, and MF tags removed and noted as reserved for backwards compatibility.
 
 \subsubsection*{July 2009}
 

--- a/SAMv1.tex
+++ b/SAMv1.tex
@@ -1214,9 +1214,11 @@ This lists the date of each tagged SAM version along with changes that
 have been made while that version was current.  The key changes
 that caused the version number to change are shown in bold.
 
-Note the auxiliary tags have now moved to their own
-specification with its own version numbering.\footnote{
-\href{http://samtools.github.io/hts-specs/SAMtags.pdf}{http://samtools.github.io/hts-specs/SAMtags.pdf}}
+Additions and changes to the standard predefined tags are listed in the
+separate {\sl Sequence Alignment/Map Optional Fields Specification}.%
+\footnote{See Appendix~A of
+\href{http://samtools.github.io/hts-specs/SAMtags.pdf}{\tt SAMtags.pdf}
+at \url{https://github.com/samtools/hts-specs}.}
 
 \subsection*{1.5: 23 May 2013 to current}
 
@@ -1234,28 +1236,22 @@ specification with its own version numbering.\footnote{
 \item Add meaning to reverse FLAG on unmapped reads. (Mar 2015)
 \item Document the {\tt idxstats} .bai elements. (Nov 2014)
 \item Addition of CSI index. (Sep 2014)
-\item Add {\tt MC} auxiliary tag. (Dec 2013)
 \item Add {\tt @PG DS} header field. (Dec 2013)
 \item Document the BAM EOF byte values. (Dec 2013)
 \item Glossary of alignment types. (May 2013)
-\item Add {\tt SA:Z} tag; PNEXT/RNEXT points to next read, not
-  segment.  (May 2013)
+\item Note that PNEXT/RNEXT points to next read, not segment. (May 2013)
 \item \textbf{Add SUPPLEMENTARY flag bit}. (May 2013)
 \end{itemize}
 
 \subsection*{1.4: 21 April 2011 to May 2013}
 
 \begin{itemize}
-\item Add guide to using sequence annotations ({\tt CT/PT tags}). (Mar 2012)
+\item Add guide to using sequence annotations ({\tt CT/PT} tags). (Mar 2012)
 \item Increase max reference length from $2^{29}$ to $2^{31}$. (Sep
   2011)
-\item Add {\tt CO} and {\tt RT} auxiliary tags. (Sep 2011)
 \item Clarify {\tt @SQ M5} header tag generation. (Sep 2011)
-\item Describe padded alignments and add {\tt CT/PT tags}. (Sep 2011)
-\item Add {\tt BC} barcode auxiliary tag. (Sep 2011)
-\item Change {\tt FZ} tag from type {\tt H} to type {\tt B,S}. (Aug 2011)
+\item Describe padded alignments. (Sep 2011)
 \item Add {\tt @RG FO}, {\tt KS} header fields. (Apr 2011)
-\item Add {\tt FZ} auxiliary tag. (Apr 2011)
 \item Clarify chaining of PG records. (Apr 2011)
 \item \textbf{Add {\tt B} array auxiliary tag type.} (Apr 2011)\
 \item \textbf{Permit IUPAC in SEQ and {\tt MD} auxiliary tag.} (Apr 2011)
@@ -1265,9 +1261,7 @@ specification with its own version numbering.\footnote{
 \subsection*{1.3: July 2010 to April 2011}
 
 \begin{itemize}
-\item Re-add {\tt CC} and {\tt CP} auxiliary tags. (Mar 2011)
 \item Add CIGAR N intron/skip operator. (Dec 2010)
-\item Add {\tt BQ} BAQ tag. (Nov 2010)
 \item Add {\tt RG PG} header field. (Nov 2010)
 \item Add BAM description and index sections. (Nov 2010)
 \item \textbf{Removal of FLAG letters.} (July 2010)


### PR DESCRIPTION
List tag additions and changes chronologically, as IMHO the main question readers want to answer is 
_When was the XY tag introduced?_

Remove SAMv1 history items pertaining to tags, as they now just duplicate SAMtags history items.

@jkbonfield @yfarjoun It would be good if we can get this in fairly rapidly, as I have some followups in mind, notably addressing James's comments on PR #307 to note the VN:1.6 bump in the SAMtags history too.