### PR TITLE
Clarification to CRAM tag encodings.

### DIFF
--- a/CRAMv3.tex
+++ b/CRAMv3.tex
@@ -597,7 +597,22 @@ section\tabularnewline
 \hline
 \end{tabular}
 
-\subsubsection*{Data series encodings}
+The tag dictionary describes the combinations of tag id / type that occur on each alignment record.
+For example if we search the id / types present in each record and find only two combinations (e.g. X1:i BC:Z SA:Z: and X1:i: BC:Z) then we have two dictionary entries in the TD map.
+
+Let $L_{i}=\{T_{i0}, T_{i1}, \ldots, T_{ix}\}$ be sorted list of all tag ids for a record $R_{i}$, where $i$ is the sequential record index and $T_{ij}$ denotes $j$-th tag id in the record.
+We recommend alphabetical sort order.
+The list of unique $L_{i}$ is assigned sequential integer numbers starting with 0.
+These integer numbers represent the TL data series.
+The sorted list of unique $L_{i}$ is stored as the TD value in the preservation map.
+Using TD, an integer from the TL data series can be mapped back into a list of tag ids.
+Thus per alignment record we only need to store tag values and not their ids and types.
+
+The TD is written as a byte array consisting of $L_{i}$ values separated with \textbackslash{}0.
+Each $L_{i}$ value is written as a sequence of 3 bytes: tag id followed by BAM tag type code (one of A, c, C, s, S, i, I, f, F, Z, H or B, as described in the SAM specification).
+For example the TD above for tag lists X1:i BC:Z SA:Z and X1:i BC:Z may be encoded as X1CBCZSAZ\textbackslash{}0X1CBCZ\textbackslash{}0, with X1C indicating a 1 byte unsigned value for tag X1.
+
+\subsubsection*{Data Series Encoding Map}
 
 Each data series has an encoding. These encoding are stored in a map with byte[2] 
 keys:
@@ -681,46 +696,26 @@ SC & encoding\texttt{<}byte[ ]\texttt{>} & soft clip & soft clipped bases\tabula
 
 * The data series is reset for each slice. 
 
-\subsubsection*{Encoding tags}
+\subsubsection*{Tag Encoding Map}
 
-The TL (tag list) data series represents combined information about the number 
-of tags in a record and their ids. 
+The encodings used for different tags are stored in a map.  Unlike the Data Series Encoding Map, the 
+key is an integer stored in ITF8, formed from the tag id and BAM type code.
+The string key matches the TD dictionary described above, with type codes according to the BAM section of the SAM specification.
+These strings are then interpreted as an integer value.
+For example, the 3-byte representation of OQ:Z is \{0x4F, 0x51, 0x5A\} and these bytes are intepreted as the integer key 0x004F515A.
 
-Let $L_{i}=\{T_{i0}, T_{i1}, \ldots, T_{ix}\}$
-be sorted list of all tag ids for a record $R_{i}$, where $i$ is the sequential 
-record index and $T_{ij}$ denotes $j$-th tag id in the record. We recommend 
-alphabetical sort order. The list of unique $L_{i}$ is assigned sequential 
-integer numbers starting with 0. These integer numbers represent the TL data series. 
-The sorted list of unique $L_{i}$ is stored as the TD value in the preservation 
-map. Using TD, an integer from the TL data series can be mapped back into a list 
-of tag ids. 
-
-The TD is written as byte array consisting of $L_{i}$ values separated 
-with \textbackslash{}0. Each $L_{i}$ value is written as a sequence 
-of 3 bytes: tag id followed by tag value type. For example AMiOQZ\textbackslash{}0OQZ\textbackslash{}0, 
-where the TD consists of just two values: integer 0 for tags \{AM:i,OQ:Z\} and 
-1 for tag \{OQ:Z\}.
-
-\subsubsection*{Encoding tag values}
-
-The encodings used for different tags are stored in a map. The map has integer 
-keys composed of the two letter tag abbreviation followed by the tag type as defined 
-in the SAM specification, for example `OQZ' for `OQ:Z'. The three bytes form a 
-big endian integer and are written as ITF8. For example, 3-byte representation 
-of OQ:Z is \{0x4F, 0x51, 0x5A\} and these bytes are intepreted as the integer 0x004F515A. 
-The integer is finally written as ITF8.
 
 \begin{tabular}{|l|l|l|>{\raggedright}p{160pt}|}
 \hline
 \textbf{Key} & \textbf{Value data type} & \textbf{Name} & \textbf{Value}
 \tabularnewline
 \hline
-TAG NAME 1:TAG TYPE 1 & encoding\texttt{<}byte[ ]\texttt{>} & read tag 1 & tag values 
+TAG ID TYPE 1 & encoding\texttt{<}byte[ ]\texttt{>} & read tag 1 & tag values 
 (names and types are available in the data series code)\tabularnewline
 \hline
 ... &  & ... & ...\tabularnewline
 \hline
-TAG NAME N:TAG TYPE N & encoding\texttt{<}byte[ ]\texttt{>} & read tag N & ...\tabularnewline
+TAG ID TYPE N & encoding\texttt{<}byte[ ]\texttt{>} & read tag N & ...\tabularnewline
 \hline
 \end{tabular}
 


### PR DESCRIPTION
This is now explicit that the type codes follow BAM conventions
(cCsSiI) and not SAM (i), along with examples to demonstrate this.
Also rearranged this so the text describing the dictionary is in the
preservation map and the text describing the "encodings" is in the Tag
Encoding Map.