### PR TITLE
Add Continuous integration to automatically generate PDF and diff-pdfs using circleCI

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -1,0 +1,18 @@
+FROM blang/latex:ubuntu
+
+MAINTAINER Louis Bergelson <louisb@broadinstitute.org>
+
+RUN apt-get update -q && \
+   apt-get install -qy nodejs npm curl && \
+   rm -rf /var/lib/apt/lists/*
+
+RUN git clone https://github.com/ftilmann/latexdiff.git && \
+    cd latexdiff && \
+    git checkout 1.3.0 && \
+    make distribution && \
+    cd dist && \
+    make install
+
+RUN npm install --global circle-github-bot@2.0.1
+
+ENV NODE_PATH=/usr/local/lib/node_modules

--- a/.circleci/README.md
+++ b/.circleci/README.md
@@ -1,0 +1,37 @@
+We use [circle-ci](https://circleci.com/gh/samtools/hts-specs) to build the pdfs and highlight the differences for each pull-request. This is done at several steps.
+
+1. Circle-ci runs `make` and copies the pdfs and log files to an "artifacts" directory for that build.
+1. Circle-ci runs `make diff` on the tex files that correspond to tex files that changed since the "merge base" (defined as the most recent common ancestor of the HEAD and master branches).
+1. Circle-ci was provided with a Token form a user (hts-specs-bot).
+1. This Token has been given permission to make comments on the github repository.
+
+
+## All about the hts-specs-bot:
+
+The [hts-specs-bot](https://github.com/hts-specs-bot) is a github account used to comment on hts-specs pull requests.
+
+## If a key needs to be rotated:
+-  Sign into the bot account. You can do this in an incognito window to avoid signing out of your existing github account.
+   -    username: `hts-specs-bot`
+   -  password: Is kept in a the hts-specs-bot google group. (See "Bot Password" below)
+-  Navigate to Settings > Developer Settings > Personal access tokens
+-  Delete the existing token
+-  Generate a new token with the `public_repo` scope.
+    - In addition to allowing the bot to make comments on pull requests, this scope allows write access to all public repos that the bot account can access.  For that reason it is **very important** not to give this bot write access to anything.
+-  Update the existing token in circle-ci by navigating to [Settings -> Environment Variables](https://circleci.com/gh/samtools/hts-specs/edit#env-vars) and replacing the existing token there with the newly generated one.
+
+### Bot Password
+If the bot account password is lost it can be recovered by sending a recovery email to hts-specs-bot@broadinstitute.org.
+Spec maintainers should be owners of that [private google group](https://groups.google.com/a/broadinstitute.org/forum/#!forum/hts-specs-bot)
+
+### Circle-CI docker image
+The docker image used by the Circle-CI build is hosted on docker under [htsspecs/circle-ci-image](https://hub.docker.com/r/htsspecs/circle-ci-image/).
+Spec maintianers should be made owners of that repository.
+
+
+## Files
+
+- .circleci/config.yml -- the configuration file that is run by circle-ci
+- .circleci/Dockerfile -- a description of the container used for running the latex and the javascript. It also has an updated version of latexdiff (githash 3e56ad7cb8e7, not an official release.) The container itself is currently htsspecs/circle-ci-image:0.4
+- .circleci/pdf_comment.js -- looks for pdfs in the diff/ directory and if it finds any, posts a comment in the github PR with links to the appropriate files
+- .circleci/Readme.md  -- this document

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,44 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: htsspecs/circle-ci-image:0.6
+    steps:
+      - checkout
+      - run:
+          name: Compile the LaTeX
+          command: |
+              make
+              mkdir pdfs
+              cp new/*.pdf pdfs
+              mkdir logs
+              cp new/*.log logs
+
+      - run:
+          name: Compile the diff LaTeX files
+          command: |
+              mergebase=$(git merge-base HEAD origin/master)
+              echo $mergebase
+
+              mkdir -p diff
+              make --touch diffs
+
+              # Avoid timing issues
+              sleep 2
+
+              touch $(git diff-tree --name-only $mergebase HEAD) || true
+
+              # Rebuild the actually changed PDFs, and remove the merely touched ones
+              make OLD=$mergebase NEW=HEAD diffs
+              find diff -mindepth 1 -empty -delete
+
+      - run:
+          name: Post PDFs to Github PR
+          command: |
+              .circleci/pdf_comment.js
+      - store_artifacts:
+          path: pdfs
+      - store_artifacts:
+          path: logs
+      - store_artifacts:
+          path: diff

--- a/.circleci/pdf_comment.js
+++ b/.circleci/pdf_comment.js
@@ -1,0 +1,43 @@
+#!/usr/bin/env nodejs
+
+const bot = require("circle-github-bot").create();
+const fs = require('fs');
+
+const spawnSync = require( 'child_process' );
+const ls = spawnSync.spawnSync( 'git', ["describe" ,"--always"]);
+
+function addLink(file){
+  text="";
+  const diffFile = "diff/"+file+".pdf";
+  const fullFile = "pdfs/"+file+".pdf";
+  console.log(file)
+  console.log(diffFile)
+  console.log(fullFile)
+
+  text += ` ${bot.artifactLink(fullFile, file)}`;
+  text += ` (${bot.artifactLink(diffFile, "diff")})`;
+  return text;
+}
+
+console.log( `git-commit: ${ls.stdout.toString()}` );
+
+const diffPDFs = fs.readdirSync("diff")
+  .filter(s=>s.match(".pdf$"));
+
+if (diffPDFs.length==0) {
+  console.log("No diffs.")
+  return;
+}
+
+diffPDFs.map(s=>s.replace(".pdf",""))
+  .forEach(file=> console.log(file))
+
+var text=`Changed PDFs as of ${ls.stdout.toString().trim()}:`
+
+text += fs.readdirSync("diff")
+	.filter(s=>s.match(".pdf$"))
+	.map(s=>s.replace(".pdf",""))
+	.map(file => addLink(file)).join(",")+".";
+
+console.log(text)
+bot.comment(process.env.GH_AUTH_TOKEN, text)

--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,8 @@
 
 GNUmakefile
 
+/diff/*.idx
+/diff/*.pdf
+/diff/*.tex
 /new/*.pdf
 /_site

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -69,6 +69,10 @@ So the usual workflow when editing these documents is (for example, when working
 (Optionally, verify that it contains the correct commit hash for your source changes.)
 Now commit your _.pdf_ changes, separately from any source changes.
 
+The _Makefile_ can also generate PDFs highlighting the typeset differences between TeX source versions, invoked by typing `make [OLD=commit [NEW=commit]] diff/SPEC.pdf`.
+By default, this compares the working _SPEC.tex_ file to the checked-out **HEAD**.
+Specify `OLD` to compare the working file to a different commit, or specify both `OLD` and `NEW` to show changes in _SPEC_ between two commits.
+
 ### Customising the build
 
 You may wish to create a file named _GNUmakefile_ (which GNU Make will read in preference to _Makefile_) as follows:

--- a/Makefile
+++ b/Makefile
@@ -17,13 +17,13 @@ pdf: $(PDFS:%=new/%)
 %.pdf: new/%.pdf
 	cp $^ $@
 
-new/CRAMv2.1.pdf: CRAMv2.1.tex new/CRAMv2.1.ver
-new/CRAMv3.pdf: CRAMv3.tex new/CRAMv3.ver
-new/SAMv1.pdf: SAMv1.tex new/SAMv1.ver
-new/SAMtags.pdf: SAMtags.tex new/SAMtags.ver
-new/VCFv4.1.pdf: VCFv4.1.tex new/VCFv4.1.ver
-new/VCFv4.2.pdf: VCFv4.2.tex new/VCFv4.2.ver
-new/VCFv4.3.pdf: VCFv4.3.tex new/VCFv4.3.ver
+new/CRAMv2.1.pdf diff/CRAMv2.1.pdf: CRAMv2.1.tex new/CRAMv2.1.ver
+new/CRAMv3.pdf   diff/CRAMv3.pdf:   CRAMv3.tex   new/CRAMv3.ver
+new/SAMv1.pdf    diff/SAMv1.pdf:    SAMv1.tex    new/SAMv1.ver
+new/SAMtags.pdf  diff/SAMtags.pdf:  SAMtags.tex  new/SAMtags.ver
+new/VCFv4.1.pdf  diff/VCFv4.1.pdf:  VCFv4.1.tex  new/VCFv4.1.ver
+new/VCFv4.2.pdf  diff/VCFv4.2.pdf:  VCFv4.2.tex  new/VCFv4.2.ver
+new/VCFv4.3.pdf  diff/VCFv4.3.pdf:  VCFv4.3.tex  new/VCFv4.3.ver
 
 PDFLATEX = pdflatex
 
@@ -39,16 +39,27 @@ new/%.ver: %.tex
 	scripts/genversion.sh $^ > $@
 
 
+diff diffs: $(PDFS:%=diff/%)
+
+OLD = HEAD
+NEW =
+
+diff/%.pdf: %.tex
+	TEXINPUTS=:..:../new latexdiff-vc --pdf --dir diff --force --git --subtype ONLYCHANGEDPAGE --graphics-markup=none --ignore-warnings --revision $(OLD) $(if $(NEW),--revision $(NEW)) $<
+
+
 show-styles:
 	@sed -n '/\\usepackage/s/.*{\(.*\)}$$/\1/p' *.tex | sort | uniq -c
 
 
 mostlyclean:
 	-rm -f new/*.aux new/*.log new/*.out new/*.toc new/*.ver
+	-rm -f diff/*.idx diff/*.out diff/*.tex diff/*.toc
 
 clean: mostlyclean
 	-rm -f $(PDFS:%=new/%)$(if $(wildcard new),; rmdir new)
+	-rm -f $(PDFS:%=diff/%)$(if $(wildcard diff),; rmdir diff)
 	-rm -rf _site
 
 
-.PHONY: all pdf show-styles mostlyclean clean
+.PHONY: all pdf diff diffs show-styles mostlyclean clean

--- a/_config.yml
+++ b/_config.yml
@@ -7,7 +7,7 @@ description: >
 baseurl: "/hts-specs"
 url: "http://samtools.github.io"
 github_username: samtools
-exclude: ["*.tex", img, MAINTAINERS.md, Makefile, new, README.md, scripts]
+exclude: ["*.tex", diff, img, MAINTAINERS.md, Makefile, new, README.md, scripts]
 
 # Build settings
 markdown: kramdown


### PR DESCRIPTION
This PR adds a continuous integration option that creates the PDFs and serves them up for perusal. 

This informs circle-ci to make all the pdfs and publish them to an accessible location.
See https://circleci.com/gh/samtools/hts-specs for build information.
