### PR TITLE
Duplicate sample IDs not allowed in header line

### DIFF
--- a/VCFv4.1.tex
+++ b/VCFv4.1.tex
@@ -150,7 +150,7 @@ The header line names the 8 fixed, mandatory columns. These columns are as follo
   \item INFO
 \end{enumerate}
 
-If genotype data is present in the file, these are followed by a FORMAT column header, then an arbitrary number of sample IDs. The header line is tab-delimited.
+If genotype data is present in the file, these are followed by a FORMAT column header, then an arbitrary number of sample IDs. Duplicate sample IDs are not allowed. The header line is tab-delimited.
 
 \subsection{Data lines}
 \subsubsection{Fixed fields}

--- a/VCFv4.2.tex
+++ b/VCFv4.2.tex
@@ -167,7 +167,7 @@ The header line names the 8 fixed, mandatory columns. These columns are as follo
   \item INFO
 \end{enumerate}
 
-If genotype data is present in the file, these are followed by a FORMAT column header, then an arbitrary number of sample IDs. The header line is tab-delimited.
+If genotype data is present in the file, these are followed by a FORMAT column header, then an arbitrary number of sample IDs. Duplicate sample IDs are not allowed. The header line is tab-delimited.
 
 \subsection{Data lines}
 \subsubsection{Fixed fields}

--- a/VCFv4.3.tex
+++ b/VCFv4.3.tex
@@ -269,6 +269,7 @@ The header line names the 8 fixed, mandatory columns. These columns are as follo
 \end{enumerate}
 
 If genotype data is present in the file, these are followed by a FORMAT column header, then an arbitrary number of sample IDs.
+Duplicate sample IDs are not allowed.
 The header line is tab-delimited and there must be no tab characters at the end of the line.
 
 \subsection{Data lines}


### PR DESCRIPTION
Many tools assume that there are no duplicate samples IDs in a VCF header line, because otherwise they can't refer to those samples by name, only by column number. This PR explicitly forbids duplicates in all versions of the specification.

Closes #323 