### PR TITLE
fixing typo in vcf specs

### DIFF
--- a/VCFv4.1.tex
+++ b/VCFv4.1.tex
@@ -879,7 +879,7 @@ Let's consider a cancer patient VCF file with 4 genomes: germline, primary\_tumo
 \begin{figure}[ht]
 \centering
 \includegraphics[width=4in,height=2.67in]{img/derivation-400x267.png}
-\caption{Pegigree example}
+\caption{Pedigree example}
 \end{figure}
 
 \begin{verbatim}

--- a/VCFv4.2.tex
+++ b/VCFv4.2.tex
@@ -896,7 +896,7 @@ Let's consider a cancer patient VCF file with 4 genomes: germline, primary\_tumo
 \begin{figure}[ht]
 \centering
 \includegraphics[width=4in,height=2.67in]{img/derivation-400x267.png}
-\caption{Pegigree example}
+\caption{Pedigree example}
 \end{figure}
 
 \begin{verbatim}

--- a/VCFv4.3.tex
+++ b/VCFv4.3.tex
@@ -1256,7 +1256,7 @@ The PEDIGREE lines would look like:
 \begin{figure}[ht]
 \centering
 \includegraphics[width=4in,height=2.67in]{img/derivation-400x267.png}
-\caption{Pegigree example}
+\caption{Pedigree example}
 \end{figure}
 
 \begin{verbatim}


### PR DESCRIPTION
fixing a typo in the vcf specs

Pegigree -> Pedigree