### PR TITLE
Support table of contents in refget and htsget. See issue #341.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -13,3 +13,4 @@ exclude: ["*.sh", "*.tex", img, new, Makefile, MAINTAINERS.md, README.md]
 markdown: kramdown
 kramdown:
   parse_block_html: true
+  toc_levels: 1..3

--- a/refget.md
+++ b/refget.md
@@ -5,6 +5,10 @@ suppress_footer: true
 ---
 
 # Refget API Specification v0.2
+{:.no_toc}
+
+* Do not remove this line (it will not be displayed)
+{:toc}
 
 ## Design principles
 Refget enables access to reference sequences using an identifier derived from the sequence itself. The API has the following features:


### PR DESCRIPTION
During refget's PRC, the reviewers suggested adding a table of contents to the specification. Kramdown can support this via the `{:toc}` tag. Anything that should not be included in the TOC is tagged with `{:.no_toc}`.

The config is setup to build the TOC for all `h1`/`h2`/`h3` tags, which on first inspection looks sufficient.

Because both refget and htsget specifications are written in Markdown it made sense to apply this to both documents.