### PR TITLE
Corrections based on the Sept 18th refget call:

### DIFF
--- a/refget.md
+++ b/refget.md
@@ -120,7 +120,7 @@ Content-type: text/vnd.ga4gh.refget.v1.0.0+plain
 
 | Parameter | Data Type | Required | Description                                                                                                                                                                                                         |
 |-----------|-----------|----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `id`      | string    | Yes      | A string specifying the sequence to be returned. The identifier shall be a checksum derived from the sequence using one of the supported checksum algorithms, or an alias for the sequence supported by the server. |
+| `id`      | string    | Yes      | A string specifying the sequence to be returned. The identifier shall be a checksum derived from the sequence using one of the supported checksum algorithms. |
 
 #### Query parameters
 
@@ -141,8 +141,6 @@ Content-type: text/vnd.ga4gh.refget.v1.0.0+plain
 The server shall return the requested sequence or sub-sequence as a single string in uppercase ASCII text (bytes 0x41-0x5A) with no line terminators or other formatting characters. The server may return the sequence in an alternative formatting, such as JSON or FASTA, if requested by the client via the `Accept` header and the format is supported by the server.
 
 On success and either a whole sequence or sub-sequence is returned the server shall issue a 200 status code if the entire sequence is returned or 206 if a sub-sequence is returned via a Range header.
-
-If a start and/or end query parameter are specified the server should include a `Accept-Ranges: none` header in the response.
 
 If the identifier is not known by the server, a 404 status code and `NotFound` error shall be returned.
 
@@ -167,7 +165,7 @@ Content-type: application/vnd.ga4gh.refget.v1.0.0+json
 
 | Parameter | Data Type | Required | Description                                                                                                                                                                                                         |
 |-----------|-----------|----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `id`      | string    | Yes      | A string specifying identifier to retrieve aliases for. The identifier shall be a checksum derived from the sequence using one of the supported checksum algorithms, or an alias for the sequence supported by the server. |
+| `id`      | string    | Yes      | A string specifying identifier to retrieve aliases for. The identifier shall be a checksum derived from the sequence using one of the supported checksum algorithms. |
 
 #### Response
 

--- a/refget.md
+++ b/refget.md
@@ -142,8 +142,6 @@ The server shall return the requested sequence or sub-sequence as a single strin
 
 On success and either a whole sequence or sub-sequence is returned the server shall issue a 200 status code if the entire sequence is returned or 206 if a sub-sequence is returned via a Range header.
 
-If a start and/or end query parameter are specified the server should include a `Accept-Ranges: none` header in the response.
-
 If the identifier is not known by the server, a 404 status code and `NotFound` error shall be returned.
 
 ### Method: Get known metadata for an id

--- a/refget.md
+++ b/refget.md
@@ -120,7 +120,7 @@ Content-type: text/vnd.ga4gh.refget.v1.0.0+plain
 
 | Parameter | Data Type | Required | Description                                                                                                                                                                                                         |
 |-----------|-----------|----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `id`      | string    | Yes      | A string specifying the sequence to be returned. The identifier shall be a checksum derived from the sequence using one of the supported checksum algorithms. |
+| `id`      | string    | Yes      | A string specifying the sequence to be returned. The identifier shall be a checksum derived from the sequence using one of the supported checksum algorithms, or an alias for the sequence supported by the server. |
 
 #### Query parameters
 
@@ -141,6 +141,8 @@ Content-type: text/vnd.ga4gh.refget.v1.0.0+plain
 The server shall return the requested sequence or sub-sequence as a single string in uppercase ASCII text (bytes 0x41-0x5A) with no line terminators or other formatting characters. The server may return the sequence in an alternative formatting, such as JSON or FASTA, if requested by the client via the `Accept` header and the format is supported by the server.
 
 On success and either a whole sequence or sub-sequence is returned the server shall issue a 200 status code if the entire sequence is returned or 206 if a sub-sequence is returned via a Range header.
+
+If a start and/or end query parameter are specified the server should include a `Accept-Ranges: none` header in the response.
 
 If the identifier is not known by the server, a 404 status code and `NotFound` error shall be returned.
 
@@ -165,7 +167,7 @@ Content-type: application/vnd.ga4gh.refget.v1.0.0+json
 
 | Parameter | Data Type | Required | Description                                                                                                                                                                                                         |
 |-----------|-----------|----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `id`      | string    | Yes      | A string specifying identifier to retrieve aliases for. The identifier shall be a checksum derived from the sequence using one of the supported checksum algorithms. |
+| `id`      | string    | Yes      | A string specifying identifier to retrieve aliases for. The identifier shall be a checksum derived from the sequence using one of the supported checksum algorithms, or an alias for the sequence supported by the server. |
 
 #### Response
 


### PR DESCRIPTION
- Accept-Ranges should not be set to None when ?start/end are suppied, "none" implies to clients the server does not support Range requests for all future requests, which is incorrect
- Aliases are not a valid query parameter, that just opens a whole can of worms of, "what if someone says '1'", which would you return if multiple sequences have that alias. Discovery of identifiers has always been external to this protocol, so a valid ID should be limited to a checksum derived from the sequence which the client has obtained from an alternative source