### PR TITLE
BND restored as a valid SVTYPE

### DIFF
--- a/VCFv4.3.tex
+++ b/VCFv4.3.tex
@@ -185,6 +185,7 @@ The first level type must be one of the following:
   \item DUP Region of elevated copy number relative to the reference
   \item INV Inversion of reference sequence
   \item CNV Copy number variable region (may be both deletion and duplication)
+  \item BND Breakend
 \end{itemize}
 
 The CNV category should not be used when a more specific category can be applied. Reserved subtypes include:
@@ -551,6 +552,7 @@ The reserved values must be used for the types listed below:
   \item DUP: Region of elevated copy number relative to the reference
   \item INV: Inversion of reference sequence
   \item CNV: Copy number variable region (may be both deletion and duplication)
+  \item BND: Breakend
 \end{itemize}
 
 \footnotesize


### PR DESCRIPTION
It got lost in a formatting commit. Fixes #347 