### PR TITLE
Add note about tag naming conventions (addresses "Inconsistent use of P suffix" issue)

### DIFF
--- a/VCFv4.3.tex
+++ b/VCFv4.3.tex
@@ -512,14 +512,15 @@ ALT haplotypes are constructed from the REF haplotype by taking the REF allele b
 In essence, the VCF record specifies a-REF-t and the alternative haplotypes are a-ALT-t for each alternative allele.
 
 \subsection{VCF tag naming conventions}
+Several tag names follow conventions indicating how their values are represented numerically:
 \begin{itemize}
-    \item The "L" suffix means "likelihood" as log-likelihood in the sampling distribution, log10 Pr(Data$|$Model).
-    Likelihoods are represented as log10 scale, thus they are negative numbers (e.g.~GL, CNL).
+    \item The `L' suffix means \emph{likelihood} as log-likelihood in the sampling distribution, $\log_{10} \Pr(\mathrm{Data}|\mathrm{Model})$.
+    Likelihoods are represented as $\log_{10}$ scale, thus they are negative numbers (e.g.~GL, CNL).
     The likelihood can be also represented in some cases as phred-scale in a separate tag (e.g.~PL).
 
-    \item The "P" suffix means "probability" as linear-scale probability in the posterior distribution, which is Pr(Model$|$Data). Examples are GP, CNP.
+    \item The `P' suffix means \emph{probability} as linear-scale probability in the posterior distribution, which is $\Pr(\mathrm{Model}|\mathrm{Data})$. Examples are GP, CNP.
 
-    \item The "Q" suffix means "quality" as log-complementary-phred-scale posterior probability, which is -10 * log10 Pr(Data$|$Model) where the model is the most likely genotype that appears in the GT field.
+    \item The `Q' suffix means \emph{quality} as log-complementary-phred-scale posterior probability, $-10 \log_{10} \Pr(\mathrm{Data}|\mathrm{Model})$, where the model is the most likely genotype that appears in the GT field.
     Examples are GQ, CNQ.
     The fixed site-level QUAL field follows the same convention (represented as a phred-scaled number).
 \end{itemize}


### PR DESCRIPTION
Mention that these conventions apply to *some* tag names where L/P/Q acts as a name suffix — for others, like DP, the L/P/Q is just part of the name. Replaces and closes #261.

Fix quote marks and maths formatting. Remove Q's superfluous “which is” to make the text fit better.