### PR TITLE
make definition of valid chars for ALT IDs consistent

### DIFF
--- a/VCFv4.3.tex
+++ b/VCFv4.3.tex
@@ -177,7 +177,7 @@ Symbolic alternate alleles are described as follows:
 
 \noindent \textbf{Structural Variants} \newline
 In symbolic alternate alleles for imprecise structural variants, the ID field indicates the type of structural variant, and can be a colon-separated list of types and subtypes.
-ID values are case sensitive strings and must not contain whitespace or angle brackets.
+ID values are case sensitive strings and must not contain whitespace, commas or angle brackets.
 The first level type must be one of the following:
 \begin{itemize}
   \item DEL Deletion relative to the reference


### PR DESCRIPTION
The definition of valid characters for ALT IDs is present in both
the metadata section and the data lines sections, and was
different.

metadata section:
> ID values are case sensitive strings and must not contain whitespace or angle brackets.

data section:
> (String; no whitespace, commas, or angle-brackets are permitted in the ID String itself) 

I'm not sure which one is the intended definition (given that this difference has been present since the VCF documents were added to the repo in 2013) , but I guess it was intended to ban commas in the IDs?

**Also**, I haven't included the changes for v4.1 and 4.2 but can do so if you think it's worth to make the retroactive change.

I would like to take the opportunity to humbly ask why the decision was made to put the definition of the same things in different places. Was it done like that to make it more reading friendly? I would suggest reassessing the option of "each definition appears only once" if there are plans to change other definitions in the future.