### PR TITLE
Clarification to CRAM tag encodings.

### DIFF
--- a/CRAMv3.tex
+++ b/CRAMv3.tex
@@ -691,11 +691,12 @@ QS & encoding\texttt{<}byte\texttt{>} & quality scores & quality scores\tabularn
 \subsubsection*{Tag encodings}
 \label{subsubsec:tags}
 
-The tag dictionary describes the combinations of tag id / type that occur on each alignment record.
+The tag dictionary (TD) describes the unique combinations of tag id / type that occur on each alignment record.
 For example if we search the id / types present in each record and find only two combinations -- X1:i BC:Z SA:Z: and X1:i: BC:Z -- then we have two dictionary entries in the TD map.
 
 Let $L_{i}=\{T_{i0}, T_{i1}, \ldots, T_{ix}\}$ be a list of all tag ids for a record $R_{i}$, where $i$ is the sequential record index and $T_{ij}$ denotes $j$-th tag id in the record.
 The list of unique $L_{i}$ is stored as the TD value in the preservation map.
+Maintaining the order is not a requirement for encoders (hence ``combinations''), but it is permissible and thus different permutations, each encoded with their own elements in TD, should be supported by the decoder.
 Each $L_{i}$ element in TD is assigned a sequential integer number starting with 0.
 These integer numbers are referred to by the TL data series.
 Using TD, an integer from the TL data series can be mapped back into a list of tag ids.
@@ -728,7 +729,8 @@ TAG ID N:TAG TYPE N & encoding\texttt{<}byte[ ]\texttt{>} & read tag N & ...\tab
 
 Note that tag values are encoded as array of bytes. The routines to convert tag 
 values into byte array and back are the same as in BAM with the exception of value 
-type being captured in the tag key rather in the value. 
+type being captured in the tag key rather in the value.
+Hence consuming 1 byte for types `C' and `c', 2 bytes for types `S' and `s', 4 bytes for types `I', `i' and `f', and a variable number of bytes for types `H', `Z' and `B'.
 
 \subsection{\textbf{Slice header block}}
 


### PR DESCRIPTION
This is now explicit that the type codes follow BAM conventions
(cCsSiI) and not SAM (i), along with examples to demonstrate this.
Also rearranged this so the text describing the dictionary is in the
preservation map and the text describing the "encodings" is in the Tag
Encoding Map.

Replaces #324