### PR TITLE
Avoid \usepackage{ulem} [trivial]

### DIFF
--- a/CRAMv2.1.tex
+++ b/CRAMv2.1.tex
@@ -13,7 +13,6 @@
 
 \usepackage{graphicx}
 \usepackage{array}
-\usepackage{ulem}
 \usepackage{fixltx2e}
 \usepackage{amssymb}
 \usepackage{fancyhdr}
@@ -72,9 +71,13 @@ enabling users to choose which data should be preserved.
 
 Data in CRAM is stored either as CRAM records or using one of the general purpose 
 compressors (gzip, bzip2). CRAM records are compressed using a number of different 
-encoding strategies. For example, bases are reference compressed (\emph{Hsi-Yang 
-Fritz, et al. (2011) Genome Res. 21:734-740}) by encoding base differences rather 
-than storing the bases themselves.
+encoding strategies. For example, bases are reference compressed by encoding base
+differences rather than storing the bases themselves.\footnote{Markus Hsi-Yang Fritz,
+Rasko Leinonen, Guy Cochrane, and Ewan Birney,
+\textbf{Efficient storage of high throughput DNA sequencing data using reference-based compression},
+{\sl Genome Res.}~2011~21: 734--740;
+\href{http://dx.doi.org/doi:10.1101/gr.114819.110}{doi:10.1101/gr.114819.110};
+{\sc pmid:}21245279.}
 
 \section{\textbf{Data types}}
 
@@ -170,7 +173,7 @@ of bits to read.
 
 \subsection{\textbf{Writing bytes to a byte stream}}
 
-The interpretation of byte stream is straightforward. CRAM uses little \emph{endiannes} 
+The interpretation of byte stream is straightforward. CRAM uses \emph{little endianness}
 for bytes when applicable and defines the following storage data types:
 
 \begin{description}
@@ -308,8 +311,8 @@ GAMMA & 9 & int offset & Elias gamma coding\tabularnewline
 \hline
 \end{tabular}
 
-A more detailed description of all the above coding algorithms and their parameters 
-can be found in the \emph{Codings }section. 
+See the later \textbf{Encodings} sections for more detailed descriptions of all
+the above coding algorithms and their parameters.
 
 \section{\textbf{File structure}}
 
@@ -907,9 +910,9 @@ of the `mapped QS included' field\tabularnewline
 *1 The AP data series is delta encoded for reads mapped to a single reference slice 
 and normal integer value in all other cases. 
 
-*2 See \emph{mate record} section.
+*2 See \textbf{mate record} section.
 
-*3 See\emph{ tag encoding} section.
+*3 See \textbf{tag encoding} section.
 
 The CRAM record structure for mapped reads has the following additional fields:
 
@@ -999,7 +1002,7 @@ records start with the number of read features followed by the read features the
 
 *1 Repeated for each read feature.
 
-*2 See \emph{read feature codes} below.
+*2 See \textbf{read feature codes} below.
 
 \subsubsection*{Read feature codes}
 

--- a/CRAMv3.tex
+++ b/CRAMv3.tex
@@ -13,7 +13,6 @@
 
 \usepackage{graphicx}
 \usepackage{array}
-\usepackage{ulem}
 \usepackage{fixltx2e}
 \usepackage{amssymb}
 \usepackage{fancyhdr}
@@ -76,9 +75,13 @@ enabling users to choose which data should be preserved.
 
 Data in CRAM is stored either as CRAM records or using one of the general purpose 
 compressors (gzip, bzip2). CRAM records are compressed using a number of different 
-encoding strategies. For example, bases are reference compressed (\emph{Hsi-Yang 
-Fritz, et al. (2011) Genome Res. 21:734-740}) by encoding base differences rather 
-than storing the bases themselves.
+encoding strategies. For example, bases are reference compressed by encoding base
+differences rather than storing the bases themselves.\footnote{Markus Hsi-Yang Fritz,
+Rasko Leinonen, Guy Cochrane, and Ewan Birney,
+\textbf{Efficient storage of high throughput DNA sequencing data using reference-based compression},
+{\sl Genome Res.}~2011~21: 734--740;
+\href{http://dx.doi.org/doi:10.1101/gr.114819.110}{doi:10.1101/gr.114819.110};
+{\sc pmid:}21245279.}
 
 \section{\textbf{Data types}}
 
@@ -175,7 +178,7 @@ of bits to read.
 \subsection{\textbf{Writing bytes to a byte stream}}
 \label{subsec:writing-bytes}
 
-The interpretation of byte stream is straightforward. CRAM uses little \emph{endianness} 
+The interpretation of byte stream is straightforward. CRAM uses \emph{little endianness}
 for bytes when applicable and defines the following storage data types:
 
 \begin{description}
@@ -310,8 +313,7 @@ GAMMA & 9 & int offset & Elias gamma coding\tabularnewline
 \hline
 \end{tabular}
 
-A more detailed description of all the above coding algorithms and their parameters 
-can be found in the \emph{Codings }section. 
+See section~\ref{sec:encodings} for more detailed descriptions of all the above coding algorithms and their parameters.
 
 \section{\textbf{Checksums}}
 The checksumming is used to ensure data integrity. The following checksumming algorithms are used in CRAM.
@@ -1551,6 +1553,7 @@ in seeking specific alignment start because all preceding records in the slice
 must be read and discarded.
 
 \section{\textbf{Encodings}}
+\label{sec:encodings}
 
 % FIXME: we have a mishash of coding, encoding and codec.  We should
 % go through the entire document and be consistent.

--- a/CRAMv3.tex
+++ b/CRAMv3.tex
@@ -22,6 +22,9 @@
 \renewcommand{\headrulewidth}{0pt}
 \renewcommand{\footrulewidth}{0pt}
 
+\newcommand\bits{\,\mbox{bits}}
+\newcommand\MB{\,\mbox{MB}}
+
 \setlength{\parindent}{0cm}
 \setlength{\parskip}{0.18cm}
 \usepackage[hmargin=2cm,vmargin=2.5cm,bindingoffset=0.0cm]{geometry}
@@ -2663,11 +2666,11 @@ $\bullet$ Streaming is more convenient for small containers
 
 $\bullet$ Applications typically buffer containers into memory
 
-We recommend 1MB containers. They are small enough to provide good random access 
+We recommend 1 megabyte containers. They are small enough to provide good random access
 and streaming performance while being large enough to provide good compression. 
-1MB containers are also small enough to fit into the L2 cache of most modern CPUs.
+1\MB\ containers are also small enough to fit into the L2 cache of most modern CPUs.
 
-Some simplified examples are provided below to fit data into 1MB containers.
+Some simplified examples are provided below to fit data into 1\MB\ containers.
 
 \textbf{Unmapped short reads with bases, read names, recalibrated and original 
 quality scores}
@@ -2675,28 +2678,28 @@ quality scores}
 We have 10,000 unmapped short reads (100bp) with read names, recalibrated and original 
 quality scores. We estimate 0.4 bits/base (read names) + 0.4 bits/base (bases) 
 + 3 bits/base (recalibrated quality scores) + 3 bits/base (original quality scores) 
-=\textasciitilde{} 7 bits/base. Space estimate is (10,000 * 100 * 7) / 8 / 1024 
-/ 1024 =\textasciitilde{} 0.9 MB. Data could be stored in a single container.
+$\approx$ 7 bits/base. Space estimate is $10\,000 \times 100 \times 7 \bits
+\approx 0.9 \MB$. Data could be stored in a single container.
 
 \textbf{Unmapped long reads with bases, read names and quality scores}
 
 We have 10,000 unmapped long reads (10kb) with read names and quality scores. We 
-estimate: 0.4 bits/base (bases) + 3 bits/base (original quality scores) =\textasciitilde{} 
-3.5 bits/base. Space estimate is (10,000 * 10,000 * 3.5) / 8 / 1024 / 1024 =\textasciitilde{} 
-42 MB. Data could be stored in 42 x 1MB containers.
+estimate: 0.4 bits/base (bases) + 3 bits/base (original quality scores) $\approx$
+3.5 bits/base. Space estimate is $10\,000 \times 10\,000 \times 3.5 \bits
+\approx 42 \MB$. Data could be stored in $42 \times 1\MB$ containers.
 
 \textbf{Mapped short reads with bases, pairing and mapping information}
 
 We have 250,000 mapped short reads (100bp) with bases, pairing and mapping information. 
-We estimate the compression to be 0.2 bits/base. Space estimate is (250,000 * 100 
-* 0.2) / 8 / 1024 / 1024 =\textasciitilde{} 0.6 MB. Data could be stored in a single 
+We estimate the compression to be 0.2 bits/base. Space estimate is $250\,000 \times 100
+\times 0.2 \bits \approx 0.6 \MB$. Data could be stored in a single
 container.
 
 \textbf{Embedded reference sequences}
 
 We have a reference sequence (10Mb). We estimate the compression to be 2 bits/base. 
-Space estimate is (10000000 * 2 / 8 / 1024 / 1024) =\textasciitilde{} 2.4MB. Data 
-could be written into three containers: 1MB + 1MB + 0.4MB.
+Space estimate is $10\,000\,000 \times 2 \bits \approx 2.4 \MB$. Data
+could be written into three containers: $1\MB + 1\MB + 0.4\MB$.
 
 \newpage
 


### PR DESCRIPTION
By adding `\renewcommand{\ULthickness}{4pt}` and eyeballing the resulting thick bars, verified that the `ulem` package was acting on the `\emph{…}` text (making it underlined rather than italics) and no other text in the two CRAM specs.

Removed `\usepackage{ulem}`. Changed the Hsi-Yang Fritz, et al. reference to a full citation footnote. Changed section references to bold or cross-references, and left other underlined text (which are all introductions/definitions of terms) to revert to italics. (Details in commit message.)

Also a second commit for your consideration, tidying up the formatting of the arithmetic in the _Choosing the container size_ appendix.

@jkbonfield et al: hopefully this is trivial enough to just merge :smile: