### PR TITLE
Add htsget 1.2.0, OpenAPI v3.0.2 spec

### DIFF
--- a/pub/htsget-openapi.yaml
+++ b/pub/htsget-openapi.yaml
@@ -9,8 +9,6 @@ info:
   contact:
     name: GA4GH
     email: security-notification@ga4gh.org
-  license:
-    name: GPLv3
 paths:
   /reads/{id}:
     get:
@@ -34,7 +32,7 @@ paths:
             type: string
         - in: "query"
           name: referenceName
-          description: VReference sequence name
+          description: Reference sequence name
           example: "chr1"
           required: false
           schema:
@@ -137,7 +135,7 @@ paths:
             type: string
         - in: "query"
           name: referenceName
-          description: VReference sequence name
+          description: Reference sequence name
           example: "chr1"
           required: false
           schema:
@@ -160,19 +158,6 @@ paths:
             type: integer
             format: int64
             minimum: 0
-        - in: "query"
-          name: fields
-          description: A list of variant fields to include, such as INFO, SAMPLE, FORMAT, etc.
-          example: "fields=INFO,SAMPLE"
-          required: false
-          schema:
-            enum:
-              - "INFO"
-              - "SAMPLE"
-              - "FILTER"
-              - "FORMAT"
-              - "ALT"
-            type: string
         - in: "query"
           name: tags
           description: A comma separated list of tags to include, by default all.

--- a/pub/htsget-openapi.yaml
+++ b/pub/htsget-openapi.yaml
@@ -12,7 +12,7 @@ info:
   license:
     name: GPLv3
 paths:
-  /reads:
+  /reads/{id}:
     get:
       summary: Gets the reads from a pre-indexed id
       operationId: searchReadId
@@ -20,8 +20,8 @@ paths:
         Searches a pre-indexed object id.
       parameters:
         - in: "path"
-          name: identifier of the read object
-          description: id
+          name: id
+          description: identifier of the read object
           required: true
           schema:
             type: string
@@ -113,7 +113,7 @@ paths:
           - read:genomic_reads
 
 
-  /variants:
+  /variants/{id}:
     get:
       summary: Gets the variants from a pre-indexed id
       operationId: searchVariantId

--- a/pub/htsget-openapi.yaml
+++ b/pub/htsget-openapi.yaml
@@ -1,0 +1,263 @@
+openapi: 3.0.0
+servers:
+  - description: htsget genomics api
+    url: https://virtserver.swaggerhub.com/brainkod/htsget/1.1.1
+info:
+  description: "This data retrieval API bridges from existing genomics bulk data transfers to a client/server model"
+  version: "1.1.1"
+  title: htsget
+  contact:
+    name: Roman Valls Guimera
+    email: brainstorm+htsget@nopcode.org
+  license:
+    name: GPLv3
+paths:
+  /reads:
+    get:
+      summary: Gets the reads from a pre-indexed id
+      operationId: searchReadId
+      description: |
+        Searches a pre-indexed object id.
+      parameters:
+        - in: "path"
+          name: identifier of the read object
+          description: id
+          required: true
+          schema:
+            type: string
+        - in: "query"
+          name: format
+          description: File format, BAM (default), CRAM.
+          example: "BAM"
+          required: false
+          schema:
+            type: string
+        - in: "query"
+          name: referenceName
+          description: VReference sequence name
+          example: "chr1"
+          required: false
+          schema:
+            type: string
+        - in: "query"
+          name: start
+          description: The start position of the range on the reference, 0-based, inclusive.
+          example: "12312"
+          required: false
+          schema:
+            type: integer
+            format: int32
+        - in: "query"
+          name: end
+          description: The end position of the range on the reference, 0-based exclusive.
+          example: "99999"
+          required: false
+          schema:
+            type: integer
+            format: int32
+        - in: "query"
+          name: fields
+          description: A list of fields to include, such as QNAME, FLAG, RNAME, etc...
+          example: "fields=QNAME,RNAME"
+          required: false
+          schema:
+            enum:
+              - "QNAME"
+              - "FLAG"
+              - "RNAME"
+              - "POS"
+              - "MAPQ"
+              - "CIGAR"
+              - "RNEXT"
+              - "PNEXT"
+              - "TLEN"
+              - "SEQ"
+              - "QUAL"
+            type: string
+        - in: "query"
+          name: tags
+          description: A comma separated list of tags to include, by default all.
+          example: "cancer,melanoma"
+          required: false
+          schema:
+            type: string
+        - in: "query"
+          name: notags
+          description: A comma separated list of tags to exclude, default none.
+          example: "normal,healthy"
+          required: false
+          schema:
+            type: string
+
+            
+      responses:
+        '200':
+          description: results matching criteria
+          content:
+            application/json:
+              schema:
+                  $ref: '#/components/schemas/readIdResponse'
+
+        '400':
+          description: something went wrong
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorResponses'
+
+        '500':
+          description: Unexpected error
+
+
+  /variants:
+    get:
+      summary: Gets the variants from a pre-indexed id
+      operationId: searchVariantId
+      description: |
+        Searches a pre-indexed object id.
+      parameters:
+        - in: "path"
+          name: id
+          description: identifier of the variant object
+          required: true
+          schema:
+            type: string
+        - in: "query"
+          name: format
+          description: File format, VCF (default), BCF.
+          example: "VCF"
+          required: false
+          schema:
+            type: string
+        - in: "query"
+          name: referenceName
+          description: VReference sequence name
+          example: "chr1"
+          required: false
+          schema:
+            type: string
+        - in: "query"
+          name: start
+          description: The start position of the range on the reference, 0-based, inclusive.
+          example: "12312"
+          required: false
+          schema:
+            type: integer
+            format: int32 #XXX: htsget spec says unsigned, swagger is signed
+        - in: "query"
+          name: end
+          description: The end position of the range on the reference, 0-based exclusive.
+          example: "99999"
+          required: false
+          schema:
+            type: integer
+            format: int32 #XXX: htsget spec says unsigned, swagger is signed
+        - in: "query"
+          name: fields
+          description: A list of variant fields to include, such as INFO, SAMPLE, FORMAT, etc.
+          example: "fields=INFO,SAMPLE"
+          required: false
+          schema:
+            enum:
+              - "INFO"
+              - "SAMPLE"
+              - "FILTER"
+              - "FORMAT"
+              - "ALT"
+            type: string
+        - in: "query"
+          name: tags
+          description: A comma separated list of tags to include, by default all.
+          example: "cancer,melanoma"
+          required: false
+          schema:
+            type: string
+        - in: "query"
+          name: notags
+          description: A comma separated list of tags to exclude, default none.
+          example: "normal,skin"
+          required: false
+          schema:
+            type: string
+
+      responses:
+        '200':
+          description: results matching criteria
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/variantIdResponse'
+        
+        '400':
+          description: something went wrong
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorResponses'
+        
+        '500':
+          description: Unexpected error
+
+components:
+  schemas:
+    readIdResponse:
+      $ref: '#/components/schemas/htsgetResponse'
+  
+    variantIdResponse:
+      $ref: '#/components/schemas/htsgetResponse'
+
+    htsgetResponse:
+      type: object
+      properties:
+        htsget:
+          type: object
+          required:
+            - format
+            - urls
+          properties:
+            format:
+              type: string
+              example:
+                "BAM"
+            urls:
+              $ref: '#/components/schemas/htsgetUrlsHeaders'
+
+            md5:
+              type: string
+              example: "8a6049fad4943ff4c6de5c22df97d001"
+
+
+    htsgetUrlsHeaders:
+      type: array
+      example: 
+        - url: "data:application/vnd.ga4gh.bam;base64,QkFNAQ=="
+        - url: "data:application/vnd.ga4gh.vcf;base64,QkFNAQ=="
+          headers:
+            "Authorization": "Bearer xxxxx"
+            "Range": "bytes=65536-1003750"
+      items:
+        $ref: '#/components/schemas/urlsItems'
+        
+    urlsItems:
+      type: object
+      required:
+        - url
+      properties:
+        url:
+          type: string
+        headers:
+          type: object
+
+    # HTTP 400 errors
+    errorResponses:
+      oneOf:
+        - $ref: '#/components/schemas/UnsupportedFormat'
+        - $ref: '#/components/schemas/InvalidInput'
+        - $ref: '#/components/schemas/InvalidRange'
+
+    UnsupportedFormat:
+      description: The requested file format is not supported by the server
+    InvalidInput:
+      description: The request parameters do not adhere to the specification
+    InvalidRange:
+      description: The requested range cannot be satisfied

--- a/pub/htsget-openapi.yaml
+++ b/pub/htsget-openapi.yaml
@@ -226,10 +226,10 @@ paths:
               example:
                 {
                    "htsget" : {
-                      "format" : "BAM",
+                      "format" : "VCF",
                       "urls" : [
                          {
-                            "url" : "https://htsget.blocksrv.example/sample1234/run1.bam",
+                            "url" : "https://htsget.blocksrv.example/sample1234/variants1.vcf",
                             "headers" : {
                                "Authorization" : "Bearer xxxx",
                                "Range" : "bytes=2744831-9375732"

--- a/pub/htsget-openapi.yaml
+++ b/pub/htsget-openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.2
 servers:
   - description: htsget genomics api
-    url: https://virtserver.swaggerhub.com/brainkod/htsget/1.2.0
+    url: "htsget/1"
 info:
   description: "This data retrieval API bridges from existing genomics bulk data transfers to a client/server model"
   version: "1.2.0"

--- a/pub/htsget-openapi.yaml
+++ b/pub/htsget-openapi.yaml
@@ -7,8 +7,8 @@ info:
   version: "1.1.1"
   title: htsget
   contact:
-    name: Roman Valls Guimera
-    email: brainstorm+htsget@nopcode.org
+    name: GA4GH
+    email: security-notification@ga4gh.org
   license:
     name: GPLv3
 paths:
@@ -46,7 +46,8 @@ paths:
           required: false
           schema:
             type: integer
-            format: int32
+            format: int64
+            minimum: 0
         - in: "query"
           name: end
           description: The end position of the range on the reference, 0-based exclusive.
@@ -54,7 +55,8 @@ paths:
           required: false
           schema:
             type: integer
-            format: int32
+            format: int64
+            minimum: 0
         - in: "query"
           name: fields
           description: A list of fields to include, such as QNAME, FLAG, RNAME, etc...
@@ -147,7 +149,8 @@ paths:
           required: false
           schema:
             type: integer
-            format: int32 #XXX: htsget spec says unsigned, swagger is signed
+            format: int64
+            minimum: 0
         - in: "query"
           name: end
           description: The end position of the range on the reference, 0-based exclusive.
@@ -155,7 +158,8 @@ paths:
           required: false
           schema:
             type: integer
-            format: int32 #XXX: htsget spec says unsigned, swagger is signed
+            format: int64
+            minimum: 0
         - in: "query"
           name: fields
           description: A list of variant fields to include, such as INFO, SAMPLE, FORMAT, etc.

--- a/pub/htsget-openapi.yaml
+++ b/pub/htsget-openapi.yaml
@@ -108,6 +108,10 @@ paths:
         '500':
           description: Unexpected error
 
+      security:
+        - htsget_auth:
+          - read:genomic_reads
+
 
   /variants:
     get:
@@ -198,6 +202,10 @@ paths:
         '500':
           description: Unexpected error
 
+      security:
+        - htsget_auth:
+          - read:genomic_variants
+
 components:
   schemas:
     readIdResponse:
@@ -261,3 +269,14 @@ components:
       description: The request parameters do not adhere to the specification
     InvalidRange:
       description: The requested range cannot be satisfied
+
+  securitySchemes:
+    htsget_auth:
+      type: oauth2
+      flows:
+        authorizationCode:
+          authorizationUrl: https://example.com/api/oauth/dialog
+          tokenUrl: https://example.com/api/oauth/token
+          scopes:
+            read:genomic_reads: read access to genomic reads
+            read:genomic_variants: read access to genomic variants

--- a/pub/htsget-openapi.yaml
+++ b/pub/htsget-openapi.yaml
@@ -1,14 +1,17 @@
-openapi: 3.0.0
+openapi: 3.0.2
 servers:
   - description: htsget genomics api
-    url: https://virtserver.swaggerhub.com/brainkod/htsget/1.1.1
+    url: https://virtserver.swaggerhub.com/brainkod/htsget/1.2.0
 info:
   description: "This data retrieval API bridges from existing genomics bulk data transfers to a client/server model"
-  version: "1.1.1"
+  version: "1.2.0"
   title: htsget
   contact:
     name: GA4GH
     email: security-notification@ga4gh.org
+externalDocs:
+  description: htsget specification
+  url: https://samtools.github.io/hts-specs/htsget.html
 paths:
   /reads/{id}:
     get:
@@ -27,6 +30,13 @@ paths:
           name: format
           description: File format, BAM (default), CRAM.
           example: "BAM"
+          required: false
+          schema:
+            type: string
+        - in: "query"
+          name: class
+          description: Request different classes of data (such as header or body).
+          example: "header"
           required: false
           schema:
             type: string
@@ -89,24 +99,51 @@ paths:
           schema:
             type: string
 
-            
+# Cannot reuse those since responses does not accept $ref directly, yet:
+# https://github.com/OAI/OpenAPI-Specification/issues/1586
       responses:
         '200':
           description: results matching criteria
           content:
             application/json:
               schema:
-                  $ref: '#/components/schemas/readIdResponse'
-
+                $ref: '#/components/schemas/IdResponse'
+              example:
+                {
+                   "htsget" : {
+                      "format" : "BAM",
+                      "urls" : [
+                         {
+                            "url" : "https://htsget.blocksrv.example/sample1234/run1.bam",
+                            "headers" : {
+                               "Authorization" : "Bearer xxxx",
+                               "Range" : "bytes=2744831-9375732"
+                            },
+                            "class" : "body"
+                         }
+                      ]
+                   }
+                }
         '400':
-          description: something went wrong
+          description: Something went wrong
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/errorResponses'
-
+                oneOf:
+                  - $ref: '#/components/schemas/UnsupportedFormat'
+                  - $ref: '#/components/schemas/InvalidInput'
+                  - $ref: '#/components/schemas/InvalidRange'
+        '401':
+          description: Authorization provided is invalid
+        '403':
+          description: Authorization is required to access the resource
+        '404':
+          $ref: '#/components/schemas/NotFound'
         '500':
-          description: Unexpected error
+          description: Internal Server Error
+        default:
+          description: Internal Server Error
+
 
       security:
         - htsget_auth:
@@ -117,8 +154,7 @@ paths:
     get:
       summary: Gets the variants from a pre-indexed id
       operationId: searchVariantId
-      description: |
-        Searches a pre-indexed object id.
+      description: Searches a pre-indexed object id.
       parameters:
         - in: "path"
           name: id
@@ -130,6 +166,13 @@ paths:
           name: format
           description: File format, VCF (default), BCF.
           example: "VCF"
+          required: false
+          schema:
+            type: string
+        - in: "query"
+          name: class
+          description: Request different classes of data (such as header or body).
+          example: "body"
           required: false
           schema:
             type: string
@@ -179,17 +222,42 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/variantIdResponse'
-        
+                $ref: '#/components/schemas/IdResponse'
+              example:
+                {
+                   "htsget" : {
+                      "format" : "BAM",
+                      "urls" : [
+                         {
+                            "url" : "https://htsget.blocksrv.example/sample1234/run1.bam",
+                            "headers" : {
+                               "Authorization" : "Bearer xxxx",
+                               "Range" : "bytes=2744831-9375732"
+                            },
+                            "class" : "body"
+                         }
+                      ]
+                   }
+                }
         '400':
-          description: something went wrong
+          description: Something went wrong
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/errorResponses'
-        
+                oneOf:
+                  - $ref: '#/components/schemas/UnsupportedFormat'
+                  - $ref: '#/components/schemas/InvalidInput'
+                  - $ref: '#/components/schemas/InvalidRange'
+        '401':
+          description: Authorization provided is invalid
+        '403':
+          description: Authorization is required to access the resource
+        '404':
+          $ref: '#/components/schemas/NotFound'
         '500':
-          description: Unexpected error
+          description: Internal Server Error
+        default:
+          description: Internal Server Error
 
       security:
         - htsget_auth:
@@ -197,10 +265,7 @@ paths:
 
 components:
   schemas:
-    readIdResponse:
-      $ref: '#/components/schemas/htsgetResponse'
-  
-    variantIdResponse:
+    IdResponse:
       $ref: '#/components/schemas/htsgetResponse'
 
     htsgetResponse:
@@ -227,8 +292,8 @@ components:
     htsgetUrlsHeaders:
       type: array
       example: 
-        - url: "data:application/vnd.ga4gh.bam;base64,QkFNAQ=="
         - url: "data:application/vnd.ga4gh.vcf;base64,QkFNAQ=="
+        - url: "https://htsget.blocksrv.example/sample1234/run1.bam"
           headers:
             "Authorization": "Bearer xxxxx"
             "Range": "bytes=65536-1003750"
@@ -245,19 +310,14 @@ components:
         headers:
           type: object
 
-    # HTTP 400 errors
-    errorResponses:
-      oneOf:
-        - $ref: '#/components/schemas/UnsupportedFormat'
-        - $ref: '#/components/schemas/InvalidInput'
-        - $ref: '#/components/schemas/InvalidRange'
-
     UnsupportedFormat:
       description: The requested file format is not supported by the server
     InvalidInput:
       description: The request parameters do not adhere to the specification
     InvalidRange:
       description: The requested range cannot be satisfied
+    NotFound:
+      description: The resource requested was not found
 
   securitySchemes:
     htsget_auth:


### PR DESCRIPTION
As mentioned over twitter:

https://twitter.com/braincode/status/1097808553723670528

I've tried to comply with the official htsget spec, from the human-readable official spec:

https://samtools.github.io/hts-specs/htsget.html

But please let me know if there's something off. Things that concern me:

1. [OpenAPI v3 only seems to have **signed** int32, while on the spec an **unsigned** int32 is required by the htsget spec](https://twitter.com/braincode/status/1098415940222431232). Granted, this is just for code scaffolding/stubs, but I hope nobody implements it wrong by accident.
1. ~~I could write in the OAuth aspects in it, but the htsget spec explicitly keeps it out since it's "beyond 
 the scope of this [htsget] specification". I feel inclined to add it regardless to ease code generation, thoughts?~~. Just went ahead and added it.
1. I've added all fields as shown in the spec for BAM, but for VCF, I just picked up some (most used ones?) from [the VCF4.2 spec](https://samtools.github.io/hts-specs/VCFv4.2.pdf). Would it make sense to list them in the hts-spec as well?