### PR TITLE
Replace Vadim with Chris Norman as CRAM maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -16,7 +16,9 @@ Past SAM/BAM maintainers include Jay Carey, Tim Fennell, and Nils Homer.
 ### CRAM
 
 * James Bonfield (@jkbonfield)
-* Vadim Zalunin (@vadimzalunin)
+* Chris Norman (@cmnbroad)
+
+Past CRAM maintainers include Vadim Zalunin.
 
 ### VCF/BCF
 


### PR DESCRIPTION
* Vadim has effectively retired as CRAM maintainer.  This would
officially replace him with Chris Norman as discussed during our last
meeting.