### PR TITLE
CRAM: The first record in a slice should have alignment-delta = 0

### DIFF
--- a/CRAMv3.tex
+++ b/CRAMv3.tex
@@ -623,8 +623,9 @@ the BAM file header\tabularnewline
 RL & encoding\texttt{<}int\texttt{>} & read lengths & read lengths\tabularnewline
 \hline
 AP & encoding\texttt{<}int\texttt{>} & in-seq positions & if \textbf{APDelta} = true: 0-based alignment start
-delta from previous record, resetting to 0 for the first record in the slice\linebreak{}
-alignment start position if \textbf{APDelta} = false\tabularnewline
+delta from the previous record.  When the record is the first in the slice,
+its alignment start will be equal to that of the slice, so its alignment delta is 0.\linebreak{}
+if \textbf{APDelta} = false: encodes the alignment start position directly\tabularnewline
 \hline
 RG & encoding\texttt{<}int\texttt{>} & read groups & read groups. Special value 
 `-1' stands for no group.\tabularnewline

--- a/CRAMv3.tex
+++ b/CRAMv3.tex
@@ -1093,7 +1093,7 @@ int & RG & read group & the read group identifier expressed as the N\textsupersc
   \State $reference\_id\gets slice\_header.reference\_sequence\_id$
 \EndIf
 \State $read\_length \gets$ \Call{ReadItem}{RL, Integer}
-\If{$container\_pmap.AP\_delta \ne 0$}
+\If{$container\_pmap.AP\_delta \ne 0$ \textbf{and} $slice\_header.reference\_sequence\_id \geq 0$}
     \State Initialise $last\_position$ to $slice\_header.alignment\_start$ if first record in slice
     \State $alignment\_position \gets$ \Call{ReadItem}{AP, Integer} + $last\_position$
     \State $last\_position \gets alignment\_position$

--- a/CRAMv3.tex
+++ b/CRAMv3.tex
@@ -623,7 +623,7 @@ the BAM file header\tabularnewline
 RL & encoding\texttt{<}int\texttt{>} & read lengths & read lengths\tabularnewline
 \hline
 AP & encoding\texttt{<}int\texttt{>} & in-seq positions & 0-based alignment start
-delta from previous record *\tabularnewline
+delta from previous record, or 0 if the first record in the slice\tabularnewline
 \hline
 RG & encoding\texttt{<}int\texttt{>} & read groups & read groups. Special value 
 `-1' stands for no group.\tabularnewline
@@ -1094,7 +1094,7 @@ int & RG & read group & the read group identifier expressed as the N\textsupersc
 \EndIf
 \State $read\_length \gets$ \Call{ReadItem}{RL, Integer}
 \If{$container\_pmap.AP\_delta \ne 0$}
-    \State Initialise $last\_position$ to 0 if first record in slice
+    \State Initialise $last\_position$ to $slice\_header.alignment\_start$ if first record in slice
     \State $alignment\_position \gets$ \Call{ReadItem}{AP, Integer} + $last\_position$
     \State $last\_position \gets alignment\_position$
 \Else

--- a/CRAMv3.tex
+++ b/CRAMv3.tex
@@ -1094,7 +1094,9 @@ int & RG & read group & the read group identifier expressed as the N\textsupersc
 \EndIf
 \State $read\_length \gets$ \Call{ReadItem}{RL, Integer}
 \If{$container\_pmap.AP\_delta \ne 0$ \textbf{and} $slice\_header.reference\_sequence\_id \geq 0$}
-    \State Initialise $last\_position$ to $slice\_header.alignment\_start$ if first record in slice
+    \If{$first\_record\_in\_slice$}
+        \State $last\_position\gets$ $slice\_header.alignment\_start$
+    \EndIf
     \State $alignment\_position \gets$ \Call{ReadItem}{AP, Integer} + $last\_position$
     \State $last\_position \gets alignment\_position$
 \Else

--- a/CRAMv3.tex
+++ b/CRAMv3.tex
@@ -622,8 +622,9 @@ the BAM file header\tabularnewline
 \hline
 RL & encoding\texttt{<}int\texttt{>} & read lengths & read lengths\tabularnewline
 \hline
-AP & encoding\texttt{<}int\texttt{>} & in-seq positions & 0-based alignment start
-delta from previous record, or 0 if the first record in the slice\tabularnewline
+AP & encoding\texttt{<}int\texttt{>} & in-seq positions & if \textbf{APDelta} = true: 0-based alignment start
+delta from previous record, resetting to 0 for the first record in the slice\linebreak{}
+alignment start position if \textbf{APDelta} = false\tabularnewline
 \hline
 RG & encoding\texttt{<}int\texttt{>} & read groups & read groups. Special value 
 `-1' stands for no group.\tabularnewline


### PR DESCRIPTION
Update the DecodePositions pseudocode to match htslib/htsjdk behavior: the state of Last Position is initialized with the Slice's Alignment Start, and therefore the Alignment Delta for the first record in a Slice is 0.