### PR TITLE
Allow C and Java native text spellings of NaN and infinities

### DIFF
--- a/VCFv4.3.tex
+++ b/VCFv4.3.tex
@@ -94,7 +94,7 @@ Characters with special meaning (such as field delimiters `\verb|;|' in INFO or 
 
 
 \subsection{Data types}
-Data types supported by VCF are: Integer (32-bit, signed), Float (32-bit, formatted to match the regular expression \verb|^[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?$|, \texttt{NaN}, or \texttt{+/-Inf}), Flag, Character, and String.
+Data types supported by VCF are: Integer (32-bit, signed), Float (32-bit IEEE-754, formatted to match one of the regular expressions \verb|^[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?$| or \verb"^[-+]?(INF|INFINITY|NAN)$" case insensitively), Flag, Character, and String.
 For the Integer type, the values from $-2^{31}$ to $-2^{31}+7$ cannot be stored in the binary version and therefore are disallowed in both VCF and BCF, see \ref{BcfTypeEncoding}.
 
 \subsection{Meta-information lines}

--- a/VCFv4.3.tex
+++ b/VCFv4.3.tex
@@ -94,7 +94,9 @@ Characters with special meaning (such as field delimiters `\verb|;|' in INFO or 
 
 
 \subsection{Data types}
-Data types supported by VCF are: Integer (32-bit, signed), Float (32-bit IEEE-754, formatted to match one of the regular expressions \verb|^[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?$| or \verb"^[-+]?(INF|INFINITY|NAN)$" case insensitively), Flag, Character, and String.
+Data types supported by VCF are: Integer (32-bit, signed), Float (32-bit IEEE-754, formatted to match one of the regular expressions \verb|^[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?$| or \verb"^[-+]?(INF|INFINITY|NAN)$" case insensitively),%
+\footnote{Note Java's {\tt Double.valueOf} is particular about capitalisation, so additional code is needed to parse all VCF infinite/NaN values.}
+Flag, Character, and String.
 For the Integer type, the values from $-2^{31}$ to $-2^{31}+7$ cannot be stored in the binary version and therefore are disallowed in both VCF and BCF, see \ref{BcfTypeEncoding}.
 
 \subsection{Meta-information lines}


### PR DESCRIPTION
The VCF v4.3 spec currently says of Float fields that they are:

> 32-bit, formatted to match the regular expression `^[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?$`, `NaN`, or `+/-Inf`.

It is not explicit whether `NaN` and `Inf` are intended to be case sensitive, but as they are adjacent to a regexp saying `…[eE]…` the reader's best guess is probably that they are indeed intended to specify that exact capitalisation.

C's `printf` outputs `+`/`-`/no sign as appropriate, followed by `nan` and `inf`/`infinity` (with `%f` etc) or `NAN` and `INF`/`INFINITY` (with `%F` etc); there is no programmer control over whether infinity is 3 or 8 letters, but current glibc and BSD libc output it as 3 letters. Its `scanf` and `strtod` accept all of those completely case-insensitively.

Java's [`Double.toString`](https://docs.oracle.com/javase/8/docs/api/java/lang/Double.html#toString-double-) outputs `NaN`, `Infinity`, or `-Infinity` signed, capitalised, and spelt exactly thus. Its [`Double.valueOf`](https://docs.oracle.com/javase/8/docs/api/java/lang/Double.html#valueOf-java.lang.String-) accepts an optional `+`/`-` sign followed by `NaN` or `Infinity` capitalised and spelt exactly thus.

Thus the VCF specification's mixed capitalisation is impossible to output using C's builtin functions, and its `+/-Inf` abbreviation is impossible to parse or output using Java's builtin functions.

In practice, htslib/bcftools outputs `nan` (samtools/bcftools#755) and htsjdk/picard outputs `Infinity` — regardless of what the spec says.

This PR fixes that by changing the VCF spec to allow the union of C and Java representations, i.e., allowing what `scanf` accepts, namely `{+,-,}{NAN,INF,INFINITY}` case-insensitively.

With this change, both input and output can be done with C's native functions and similarly Java can output Floats with `Double.toString`. Java input will still need special case code to parse otherwise-cased and abbreviated NaNs and infinities, but that's inevitable given `Double.valueOf`'s inflexibility.

See also previous discussions in https://github.com/samtools/bcftools/issues/755#issuecomment-455240246 and https://github.com/samtools/hts-specs/issues/89#issuecomment-455503658.
