### PR TITLE
Update CRAM spec section on substitution matrix and codes.

### DIFF
--- a/CRAMv3.tex
+++ b/CRAMv3.tex
@@ -1389,8 +1389,9 @@ in the substitution matrix.
 
 Each of the 4 possible substitutions for a given reference base is assigned a 2-bit integer
 code (see below) with a value ranging from 0 to 3 inclusive. The 4 2-bit codes are packed
-into a single byte,  in the fixed order ACGTN, and the entire substitution matrix is
-written as 5 such bytes, one for each reference base, also in the order ACGTN.
+into a single byte, high 2-bits first, for each base ACGTN (minus the reference base itself).
+The entire substitution matrix is written as 5 such bytes, one for each reference base, also
+in the order ACGTN.
 
 \subsubsection*{Substitution Code Assignment}
 

--- a/CRAMv3.tex
+++ b/CRAMv3.tex
@@ -1395,11 +1395,11 @@ in the order ACGTN.
 
 \subsubsection*{Substitution Code Assignment}
 
-To assign the susbtitution code for a given reference base/read base, the subsitutions for
+To assign the susbtitution code for a given reference base/read base, the substitutions for
 each reference base may optionally be sorted by their frequencies, in descending order, with
 same-frequency ties broken using the fixed order ACGTN. Although sorting by substitution
 frequency is not required by the CRAM format, assigning substitution codes based on frequency
-maximizes compression by ensuring that the most frequent subsitutions use the shortest possible
+maximizes compression by ensuring that the most frequent substitutions use the shortest possible
 codes.
 
 For example, let us assume the following substitution frequencies for base A: 
@@ -1422,11 +1422,9 @@ AT: 0
 
 AN: 3
 
-The substitution matrix entry for this reference base then is written as a single byte, with the
-codes in the order CGTN: 10 01 00 11 = 147 decimal, or 0x93 in this case.
-
-Note that the last two bits of the substitution matrix entry are redundant, since the remaining
-code could be derived from the rest of the entry, but are retained for simplicity.
+The first byte of the substitution matrix entry for reference base A is written as a single byte,
+with the codes in the order CGTN: 10 01 00 11 = 147 decimal, or 0x93 in this case. This will then
+be followed by 4 more bytes representing substitutions for reference bases C, G, T and N.
 
 \subsubsection*{Decode mapped read pseudocode}
 

--- a/CRAMv3.tex
+++ b/CRAMv3.tex
@@ -1378,19 +1378,30 @@ Hard clip & H (0x48) & int & HC & number of hard clipped bases, SAM operator H\t
 
 \subsubsection*{Base substitution codes (BS data series)}
 
-A base substitution is defined as a change from one nucleotide base (reference 
-base) to another (read base) including N as an unknown or missing base. There are 
-5 possible bases ACGTN, 4 possible substitutions for each base and 20 substitutions 
-in total. Substitutions for the same reference base are assigned integer codes 
-from 0 to 3 inclusive. To restore a base one would need to know its substitution 
-code and the reference base. 
+A base substitution is defined as a change from one nucleotide base (reference base) to
+another (read base), including N as an unknown or missing base. There are 5 possible reference
+bases (ACGTN), with 4 possible substitutions for each base, and 20 substitutions in total.
+The codes for all possible substitutions are stored in a substitution matrix. To restore a
+base, one would use the reference base and the substitution code, resolving the base via lookup
+in the substitution matrix.
 
-A base substitution matrix assigns integer codes to all possible substitutions. 
+\subsubsection*{Substitution Matrix Format}
 
-Substitution matrix is written as follows. Substitutions for a given reference 
-base are sorted by their frequencies in descending order then assigned numbers 
-from 0 to 3. Same-frequency ties are broken using alphabetical order. For example, 
-let us assume the following substitution frequencies for base A: 
+Each of the 4 possible substitutions for a given reference base is assigned a 2-bit integer
+code (see below) with a value ranging from 0 to 3 inclusive. The 4 2-bit codes are packed
+into a single byte,  in the fixed order ACGTN, and the entire substitution matrix is
+written as 5 such bytes, one for each reference base, also in the order ACGTN.
+
+\subsubsection*{Substitution Code Assignment}
+
+To assign the susbtitution code for a given reference base/read base, the subsitutions for
+each reference base may optionally be sorted by their frequencies, in descending order, with
+same-frequency ties broken using the fixed order ACGTN. Although sorting by substitution
+frequency is not required by the CRAM format, assigning substitution codes based on frequency
+maximizes compression by ensuring that the most frequent subsitutions use the shortest possible
+codes.
+
+For example, let us assume the following substitution frequencies for base A: 
 
 AC: 15\%
 
@@ -1410,12 +1421,11 @@ AT: 0
 
 AN: 3
 
-and they are written as a single byte, 10 01 00 11 = 147 decimal or 0x93 in this 
-case. The whole substitution matrix is written as 5 bytes, one for each reference 
-base in the alphabetical order: A, C, G, T and N.
+The substitution matrix entry for this reference base then is written as a single byte, with the
+codes in the order CGTN: 10 01 00 11 = 147 decimal, or 0x93 in this case.
 
-Note: the last two bits of each substitution code are redundant but still required 
-to simplify the reading. 
+Note that the last two bits of the substitution matrix entry are redundant, since the remaining
+code could be derived from the rest of the entry, but are retained for simplicity.
 
 \subsubsection*{Decode mapped read pseudocode}
 


### PR DESCRIPTION
Based on the discussion in https://github.com/samtools/hts-specs/issues/408. @jkbonfield I left the section on substitution frequency sorting in, since it motivates the need for the substitution matrix (otherwise the codes could just be fixed). See what you think.