### PR TITLE
Fix PEDIGREE example errors; draft of familial PEDIGREE section

### DIFF
--- a/VCFv4.1.tex
+++ b/VCFv4.1.tex
@@ -865,13 +865,13 @@ Analogously, there might also be several normal genomes from the same patient in
 The general format of a PEDIGREE line describing asexual, clonal derivation is:
 
 \begin{verbatim}
-PEDIGREE=<Derived=ID2,Original=ID1>
+##PEDIGREE=<Derived=ID2,Original=ID1>
 \end{verbatim}
 
-This line asserts that the DNA in genome is asexually or clonally derived with mutations from the DNA in genome . This is the asexual analog of the VCF format that has been proposed for family relationships between genomes, i.e., there is one entry per of the form:
+This line asserts that the DNA in genome ID2 is asexually or clonally derived with mutations from the DNA in genome ID1. This is the asexual analog of the VCF format that has been proposed for family relationships between genomes, i.e., there is one entry per trio of the form:
 
 \begin{verbatim}
-PEDIGREE=<Child=CHILD-GENOME-ID,Mother=MOTHER-GENOME-ID,Father=FATHER-GENOME-ID>
+##PEDIGREE=<Child=CHILD-GENOME-ID,Mother=MOTHER-GENOME-ID,Father=FATHER-GENOME-ID>
 \end{verbatim}
 
 Let's consider a cancer patient VCF file with 4 genomes: germline, primary\_tumor, secondary\_tumor1, and secondary\_tumor2 as illustrated in Figure 10. The primary\_tumor is derived from the germline and the secondary tumors are each derived independently from the primary tumor, in all cases by clonal derivation with mutations. The PEDIGREE lines would look like:

--- a/VCFv4.2.tex
+++ b/VCFv4.2.tex
@@ -882,13 +882,13 @@ Analogously, there might also be several normal genomes from the same patient in
 The general format of a PEDIGREE line describing asexual, clonal derivation is:
 
 \begin{verbatim}
-PEDIGREE=<Derived=ID2,Original=ID1>
+##PEDIGREE=<Derived=ID2,Original=ID1>
 \end{verbatim}
 
-This line asserts that the DNA in genome ID2 is asexually or clonally derived with mutations from the DNA in genome ID1. This is the asexual analog of the VCF format that has been proposed for family relationships between genomes, i.e., there is one entry per of the form:
+This line asserts that the DNA in genome ID2 is asexually or clonally derived with mutations from the DNA in genome ID1. This is the asexual analog of the VCF format that has been proposed for family relationships between genomes, i.e., there is one entry per trio of the form:
 
 \begin{verbatim}
-PEDIGREE=<Child=CHILD-GENOME-ID,Mother=MOTHER-GENOME-ID,Father=FATHER-GENOME-ID>
+##PEDIGREE=<Child=CHILD-GENOME-ID,Mother=MOTHER-GENOME-ID,Father=FATHER-GENOME-ID>
 \end{verbatim}
 
 Let's consider a cancer patient VCF file with 4 genomes: germline, primary\_tumor, secondary\_tumor1, and secondary\_tumor2 as illustrated in Figure 10. The primary\_tumor is derived from the germline and the secondary tumors are each derived independently from the primary tumor, in all cases by clonal derivation with mutations. The PEDIGREE lines would look like:

--- a/VCFv4.3.tex
+++ b/VCFv4.3.tex
@@ -253,7 +253,7 @@ It is possible to record relationships between genomes using the following synta
 ##pedigreeDB=URL
 \end{verbatim}
 
-\noindent See \ref{PedigreeInDetail} for details.
+\noindent See \ref{ClonalPedigree} (clonal relationships) and \ref{FamilialPedigree} (trios and families) for details.
 
 
 \subsection{Header line syntax}
@@ -1238,7 +1238,7 @@ However, a more evolved algorithm could attempt actually deconvolving the two ge
 \normalsize
 
 \subsubsection{Clonal derivation relationships}
-\label{PedigreeInDetail}
+\label{ClonalPedigree}
 In cancer, each VCF file represents several genomes from a patient, but one genome is special in that it represents the germline genome of the patient.
 This genome is contrasted to a second genome, the cancer tumor genome.
 In the simplest case the VCF file for a single patient contains only these two genomes.
@@ -1258,7 +1258,7 @@ The general format of a PEDIGREE line describing asexual, clonal derivation is:
 \end{verbatim}
 
 This line asserts that the DNA in genome DerivedID is asexually or clonally derived with mutations from the DNA in genome OriginalID.
-This is the asexual analog of the VCF format that has been proposed for family relationships between genomes, i.e., there is one entry per trio of the form:
+This is the asexual analog of the VCF format that has been proposed for family relationships between genomes (see~\ref{FamilialPedigree}), in which there is one entry per trio of the form:
 
 \begin{verbatim}
 ##PEDIGREE=<ID=ChildID,Mother=MotherID,Father=FatherID>
@@ -1379,6 +1379,19 @@ Example records are given below:
 \end{tabular}
 \end{flushleft}
 \normalsize
+
+\subsection{Describing family relationships}
+\label{FamilialPedigree}
+
+This is the VCF format that has been proposed for family relationships between genomes, in which there is one entry per trio of the form:
+
+\begin{verbatim}
+##PEDIGREE=<ID=ChildID,Mother=MotherID,Father=FatherID>
+\end{verbatim}
+
+TODO: Text describing meaning of Mother and Father well-known ancestor tags
+and explaining how to represent a PED file as in-line \#\#PEDIGREE trios.
+Noting alternatively to use \#\#pedigreeDB=URL to point to an external PED file.
 
 \pagebreak
 \section{BCF specification}

--- a/VCFv4.3.tex
+++ b/VCFv4.3.tex
@@ -1254,14 +1254,14 @@ These normal genomes are then considered to be derived from the original germlin
 The general format of a PEDIGREE line describing asexual, clonal derivation is:
 
 \begin{verbatim}
-PEDIGREE=<ID=DerivedID,Original=OriginalID>
+##PEDIGREE=<ID=DerivedID,Original=OriginalID>
 \end{verbatim}
 
-This line asserts that the DNA in genome is asexually or clonally derived with mutations from the DNA in genome.
-This is the asexual analog of the VCF format that has been proposed for family relationships between genomes, i.e., there is one entry per of the form:
+This line asserts that the DNA in genome DerivedID is asexually or clonally derived with mutations from the DNA in genome OriginalID.
+This is the asexual analog of the VCF format that has been proposed for family relationships between genomes, i.e., there is one entry per trio of the form:
 
 \begin{verbatim}
-PEDIGREE=<ID=ChildID,Mother=MotherID,Father=FatherID>
+##PEDIGREE=<ID=ChildID,Mother=MotherID,Father=FatherID>
 \end{verbatim}
 
 Let's consider a cancer patient VCF file with 4 genomes: germline, primary\_tumor, secondary\_tumor1, and secondary\_tumor2 as illustrated in Figure 10.


### PR DESCRIPTION
Two separate commits, the first fixing obvious errors and the second an outline of a suggested new “Describing family relationships” section:

1. Add missing `##` and other words; replicate 2016's PR #176's fixes in the other copies of the spec.

2. Outline of a new “Describing family relationships” section that would address #381 by explaining how the `##PEDIGREE` trio metadata line shown in the VCF spec is supposed to work and how it corresponds to an external PED file.

    Previous discussion has suggested that this functionality is thought to be stillborn. If so, the examples should be removed from the specs. Otherwise if the functionality is used out there, it would be good for the spec to describe the (fairly obvious) way in which it would be intended to be used.