### PR TITLE
nominate @jeromekelleher and @jmarshall as additional htsget maintainers

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -30,7 +30,9 @@ Past VCF/BCF maintainers include Ryan Poplin and David Roazen.
 
 ### Htsget
 
+* Jerome Kelleher (@jeromekelleher)
 * Mike Lin (@mlin)
+* John Marshall (@jmarshall)
 
 ### Refget
 


### PR DESCRIPTION
Presently I'm the only officially listed maintainer of the htsget spec, which may create bottlenecks when I have limited availability. @jeromekelleher and @jmarshall are nominated here. This was aired on the mailing list a couple of weeks ago with only supportive comments to date.