### PR TITLE
htsget: add `samples` query parameter, principally to select subset of VCF columns

### DIFF
--- a/htsget.md
+++ b/htsget.md
@@ -254,6 +254,16 @@ A comma separated list of tags to exclude, default: none.
 
 The server SHOULD respond with an `InvalidInput` error if `tags` and `notags` intersect.
 </td></tr>
+<tr markdown="block"><td>
+
+`samples`  
+_optional_
+</td><td>
+A comma separated list of samples to include, default: all. For VCF responses, this selects a subset of columns from a multi-sample VCF dataset.
+
+The server SHOULD respond with an `InvalidInput` error if a nonexistent `sample` is listed.
+</td></tr>
+<tr markdown="block"><td>
 </table>
 
 ### Field filtering


### PR DESCRIPTION
e.g.

```
GET /htsget/1000genomes/variants?format=VCF&samples=NA12878,NA12877
```

Previously I circulated a different version of this with a repeated `sample=x` query parameter. This single, comma separated list is more consistent with the existing `fields` & `tags` query parameters.