### PR TITLE
Clarify the meaning of INFO/END

### DIFF
--- a/VCFv4.3.tex
+++ b/VCFv4.3.tex
@@ -327,7 +327,7 @@ Fixed fields are:
   INFO fields are encoded as a semicolon-separated series of short keys with optional values in the format: key[=data[,data]].
   INFO keys must match the regular expression \texttt{\^{}([A-Za-z\_][0-9A-Za-z\_.]*|1000G)\$}, please note that ``1000G'' is allowed as a special legacy value.
   Duplicate keys are not allowed.
-  Arbitrary keys are permitted, although those listed in Table~\ref{table:reserved-info} are reserved (albeit optional).
+  Arbitrary keys are permitted, although those listed in Table~\ref{table:reserved-info} and described below are reserved (albeit optional).
 
   The exact format of each INFO key should be specified in the meta-information (as described above).
   Example for an INFO field: DP=154;MQ=52;H2.
@@ -358,7 +358,7 @@ Fixed fields are:
 	CIGAR		& A		& String	& Cigar string describing how to align an alternate allele to the reference allele \\
 	DB		& 0		& Flag		& dbSNP membership \\
 	DP		& 1		& Integer	& Combined depth across samples \\
-	END		& 1		& Integer	& End position (for use with symbolic alleles) \\
+	END		& 1		& Integer	& End position on CHROM (used with symbolic alleles; see below) \\
 	H2		& 0		& Flag		& HapMap2 membership \\
 	H3		& 0		& Flag		& HapMap3 membership \\
 	MQ		& 1		& Float		& RMS mapping quality \\
@@ -369,6 +369,15 @@ Fixed fields are:
 	VALIDATED	& 0		& Flag		& Validated by follow-up experiment \\
 	1000G		& 0		& Flag		& 1000 Genomes membership \\
 \end{longtable}
+
+\begin{itemize}
+\renewcommand{\labelitemii}{$\circ$}
+\item END: End reference position (1-based), indicating the variant spans positions POS--END on reference/contig CHROM.
+Normally this is the position of the last base in the REF allele, so it can be derived from POS and the length of REF, and no END INFO field is needed.
+However when symbolic alleles are used, e.g.\ in gVCF or structural variants, an explicit END INFO field provides variant span information that is otherwise unknown.
+
+This field is used to compute BCF's {\tt rlen} field (see~\ref{BcfSiteEncoding}) and is important when indexing VCF/BCF files to enable random access and querying by position.
+\end{itemize}
 
 \subsubsection{Genotype fields}
 If genotype information is present, then the same types of data must be present for all samples.
@@ -1496,6 +1505,7 @@ The genotype data may be omitted entirely from the record if there is no genotyp
 Compression of a BCF file is recommended but not required.
 
 \subsubsection{Site encoding}
+\label{BcfSiteEncoding}
 
 {\small
 \begin{tabular}{|l | l | p{30em} | } \hline


### PR DESCRIPTION
INFO/END (when present) determines (together with the CHROM and POS fields) the interval that the variant is located in. This is used when indexing VCF/BCF files, as can be gleaned from §6.3.1's description of BCF's rlen field.

In particular, INFO/END must be on the same chromosome as CHROM and come after POS, otherwise .csi/.tbi indexing will not work. This is implied by the existing description of `rlen`:

> Length of the record as projected onto the reference sequence. Must be the length of the REF allele or the declared length of a symbolic allele respecting the END attribute

but that is hardly obvious, and people looking up INFO/END are unlikely to read it anyway — as it's in the BCF part of the spec.

There has been some discussion of this on PR #266 (starting at https://github.com/samtools/hts-specs/pull/266#discussion_r282908254, hat tip @cwhelan), but that has not resulted in any clarifying text being added in that PR. That PR is likely to take a while yet to land, so here is a separate PR that clarifies INFO/END and can hopefully be merged quickly.

Fixes #425.