### PR TITLE
[Meta] Codify the existing policy of generally squashing PRs

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -50,6 +50,10 @@ Larger changes should be proposed as pull requests so that they can be discussed
 (Even those with write access to the **samtools/hts-specs** repository should in general create their pull request branches within their own **hts-specs** forks.
 This way when the main repository is forked again, the new fork is created with a minimum of extraneous volatile branches.)
 
+In general, pull requests should be squashed and rebased before merging: _squashed_ to avoid immortalising trivial editorial commits that occurred during refinement of the PR, and _rebased_ (where practical) to avoid unnecessary merge commits.
+Cases where this shouldn't be done include pull requests with multiple non-trivial commits (e.g., separate changes, or a series of commits that tells a story), which should be rebased and/or, if the branch point is reasonably recent, simply merged with a merge commit.
+
+Ensure that the pull request number is present in the resulting commit history, either in the merge commit message or by adding `(PR #NNN)` to the first line of the squashed commit or one that is representative of the PR.
 
 ## Generating PDF specification documents
 


### PR DESCRIPTION
Some text that spells out our de facto policy around how to merge PRs (AIUI at least). Mostly our PRs are a single commit that gets modified by a stream of meaningless “fix typo” and “respond to review” commits, so in the usual case that should all be squashed into one commit when the PR is merged.

However there are occasional cases of PRs that tell a story or otherwise have distinct non-trivial commits, so spell out that other treatment for such cases is appropriate.

The **hts-specs** repository currently has all three GitHub UI merge strategies (merge commit; squash; rebase) switched on. It doesn't seem to be possible to change the default; I think it defaults to whatever was selected previously (in the repo / by you / both). We could switch off some of the strategies (i.e. merge commit) and require such things to be done on the command line, but I'm not sure that's better than education + status quo.