### PR TITLE
Specify defaults to booleans in CRAM preservation map

### DIFF
--- a/CRAMv3.tex
+++ b/CRAMv3.tex
@@ -615,6 +615,8 @@ section\tabularnewline
 \hline
 \end{tabular}
 
+The boolean values are optional, defaulting to true when absent, although it is recommended to explicitly set them.  SM and TD are mandatory.
+
 \subsubsection*{Data series encodings}
 
 Each data series has an encoding. These encoding are stored in a map with byte[2] 


### PR DESCRIPTION
Fixes #120

I decided after consideration that SM and TD should be mandatory.  TD because TL data series is mandatory so we always look up in TD even when no tags are prevent, so we'd have to specify that blank TD as the default.  SM likewise; it's easier to make it mandatory than to specify the default value.

In both cases there appears to be no way in existing code to create CRAMs that does not add these fields.