### PR TITLE
Fixed the circle-ci build so it works on longtable

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -3,7 +3,7 @@ FROM blang/latex:ubuntu
 MAINTAINER Louis Bergelson <louisb@broadinstitute.org>
 
 RUN apt-get update -q && \
-   apt-get install -qy nodejs npm curl && \
+   apt-get install -qy nodejs npm curl ghostscript && \
    rm -rf /var/lib/apt/lists/*
 
 RUN git clone https://github.com/ftilmann/latexdiff.git && \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: htsspecs/circle-ci-image:0.6
+      - image: htsspecs/circle-ci-image:0.7
     steps:
       - checkout
       - run:

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ OLD = HEAD
 NEW =
 
 diff/%.pdf: %.tex
-	BIBINPUTS=:.. TEXINPUTS=:..:../new latexdiff-vc --pdf --dir diff --force --git --subtype ONLYCHANGEDPAGE --graphics-markup=none --ignore-warnings --revision $(OLD) $(if $(NEW),--revision $(NEW)) $<
+	BIBINPUTS=:.. TEXINPUTS=:..:../new latexdiff-vc --pdf --dir diff --force --git --only-changes --graphics-markup=none --ignore-warnings --revision $(OLD) $(if $(NEW),--revision $(NEW)) $<
 
 
 show-styles:
@@ -56,7 +56,7 @@ show-styles:
 
 mostlyclean:
 	-rm -f new/*.aux new/*.bbl new/*.blg new/*.log new/*.out new/*.toc new/*.ver
-	-rm -f diff/*.blg diff/*.idx diff/*.out diff/*.tex diff/*.toc
+	-rm -f diff/**.aux diff/*.blg diff/*.idx diff/*.log diff/*.out diff/*.tex diff/*.toc
 
 clean: mostlyclean
 	-rm -f $(PDFS:%=new/%)$(if $(wildcard new),; rmdir new)


### PR DESCRIPTION
fixed the build so that difflatex uses  `--only-changes` (need a gs…… upgrade as well)

This fixes the the creation of the difflatex pdfs for long tables