### PR TITLE
Clarify that RG-PL is omitted for unknown/other platforms (alternative to PL:OTHER)

### DIFF
--- a/SAMv1.tex
+++ b/SAMv1.tex
@@ -312,7 +312,8 @@ The {\tt TP} field is often omitted, which implies linear.}\\\cline{2-3}
   & {\tt PG} & Programs used for processing the read group.\\\cline{2-3}
   & {\tt PI} & Predicted median insert size.\\\cline{2-3}
   & {\tt PL} & Platform/technology used to produce the reads. \emph{Valid values}:
-  {\tt CAPILLARY}, {\tt LS454}, {\tt ILLUMINA}, {\tt SOLID}, {\tt HELICOS}, {\tt IONTORRENT}, {\tt ONT}, and {\tt PACBIO}.\\\cline{2-3}
+  {\tt CAPILLARY}, {\tt LS454}, {\tt ILLUMINA}, {\tt SOLID}, {\tt HELICOS}, {\tt IONTORRENT}, {\tt ONT}, and {\tt PACBIO}.
+  Omitted when the platform is not in this list (though the {\tt PM} tag may still be present in this case) or is unknown.\\\cline{2-3}
   & {\tt PM} & Platform model. Free-form text providing further details of the
   platform/technology used.\\\cline{2-3}
   & {\tt PU} & Platform unit (e.g., flowcell-barcode.lane for Illumina or slide for SOLiD). Unique identifier.\\\cline{2-3}


### PR DESCRIPTION
As a concrete proposal for an alternative to `@RG PL:OTHER`, here is a sentence clarifying what is indicated when `PL` is omitted (and thus also clarifying that omitting it is valid).

This is option (1) from <https://github.com/samtools/hts-specs/pull/454#issuecomment-553941441>. To my mind, this has equivalent expressiveness to the `OTHER` proposal but avoids adding a meaningless keyword to the specification.

See also previous discussion on #454.