### PR TITLE
VCF: Clarify * as overlapping allele, not overlapping base #437

### DIFF
--- a/VCFv4.3.tex
+++ b/VCFv4.3.tex
@@ -317,8 +317,7 @@ Fixed fields are:
 
   \item ALT --- alternate base(s): Comma separated list of alternate non-reference alleles.
   These alleles do not have to be called in any of the samples.
-  Options are base Strings made up of the bases A,C,G,T,N,*, (case insensitive) or a MISSING value `.' (no variant) or an angle-bracketed ID String (``$<$ID$>$'') or a breakend replacement string as described in the section on breakends.
-  The `*' allele is reserved to indicate that the allele is missing due to an overlapping deletion.
+  Options are base Strings made up of the bases A,C,G,T,N (case insensitive) or the `*' symbol (allele missing due to overlapping deletion) or a MISSING value `.' (no variant) or an angle-bracketed ID String (``$<$ID$>$'') or a breakend replacement string as described in the section on breakends.
   If there are no alternative alleles, then the MISSING value must be used.
   Tools processing VCF files are not required to preserve case in the allele String, except for IDs, which are case sensitive.
   (String; no whitespace, commas, or angle-brackets are permitted in the ID String itself)

--- a/VCFv4.3.tex
+++ b/VCFv4.3.tex
@@ -317,8 +317,9 @@ Fixed fields are:
 
   \item ALT --- alternate base(s): Comma separated list of alternate non-reference alleles.
   These alleles do not have to be called in any of the samples.
-  Options are base Strings made up of the bases A,C,G,T,N (case insensitive) or the `*' symbol (allele missing due to overlapping deletion) or a MISSING value `.' (no variant) or an angle-bracketed ID String (``$<$ID$>$'') or a breakend replacement string as described in the section on breakends.
+  Options are base Strings made up of the bases A,C,G,T,N (case insensitive) or the `*' symbol (allele missing due to overlapping deletion) or a MISSING value `.' (no variant) or an angle-bracketed ID String (``$<$ID$>$'') or a breakend replacement string as described in Section \ref{Breakends}.
   If there are no alternative alleles, then the MISSING value must be used.
+  In other words, the ALT field must be a symbolic allele, or a breakend replacement string, or match the regular expression \texttt{\^{}([ACGTNacgtn]+|\string\*|\string\.)\$}.
   Tools processing VCF files are not required to preserve case in the allele String, except for IDs, which are case sensitive.
   (String; no whitespace, commas, or angle-brackets are permitted in the ID String itself)
   \item QUAL --- quality: Phred-scaled quality score for the assertion made in ALT. i.e.\ $-10log_{10}$ prob(call in ALT is wrong).
@@ -876,6 +877,7 @@ VCF STRUCTURAL VARIANT EXAMPLE
 \normalsize
 
 \subsection{Specifying complex rearrangements with breakends}
+\label{Breakends}
 
 An arbitrary rearrangement event can be summarized as a set of novel \textbf{adjacencies}. Each adjacency ties together $2$ \textbf{breakends}.
 The two breakends at either end of a novel adjacency are called \textbf{mates}.

--- a/VCFv4.4.tex
+++ b/VCFv4.4.tex
@@ -317,8 +317,7 @@ Fixed fields are:
 
   \item ALT --- alternate base(s): Comma separated list of alternate non-reference alleles.
   These alleles do not have to be called in any of the samples.
-  Options are base Strings made up of the bases A,C,G,T,N,*, (case insensitive) or a MISSING value `.' (no variant) or an angle-bracketed ID String (``$<$ID$>$'') or a breakend replacement string as described in the section on breakends.
-  The `*' allele is reserved to indicate that the allele is missing due to an overlapping deletion.
+  Options are base Strings made up of the bases A,C,G,T,N (case insensitive) or the `*' symbol (allele missing due to overlapping deletion) or a MISSING value `.' (no variant) or an angle-bracketed ID String (``$<$ID$>$'') or a breakend replacement string as described in the section on breakends.
   If there are no alternative alleles, then the MISSING value must be used.
   Tools processing VCF files are not required to preserve case in the allele String, except for IDs, which are case sensitive.
   (String; no whitespace, commas, or angle-brackets are permitted in the ID String itself)

--- a/VCFv4.4.tex
+++ b/VCFv4.4.tex
@@ -317,8 +317,9 @@ Fixed fields are:
 
   \item ALT --- alternate base(s): Comma separated list of alternate non-reference alleles.
   These alleles do not have to be called in any of the samples.
-  Options are base Strings made up of the bases A,C,G,T,N (case insensitive) or the `*' symbol (allele missing due to overlapping deletion) or a MISSING value `.' (no variant) or an angle-bracketed ID String (``$<$ID$>$'') or a breakend replacement string as described in the section on breakends.
+  Options are base Strings made up of the bases A,C,G,T,N (case insensitive) or the `*' symbol (allele missing due to overlapping deletion) or a MISSING value `.' (no variant) or an angle-bracketed ID String (``$<$ID$>$'') or a breakend replacement string as described in Section \ref{Breakends}.
   If there are no alternative alleles, then the MISSING value must be used.
+  In other words, the ALT field must be a symbolic allele, or a breakend replacement string, or match the regular expression \texttt{\^{}([ACGTNacgtn]+|\string\*|\string\.)\$}.
   Tools processing VCF files are not required to preserve case in the allele String, except for IDs, which are case sensitive.
   (String; no whitespace, commas, or angle-brackets are permitted in the ID String itself)
   \item QUAL --- quality: Phred-scaled quality score for the assertion made in ALT. i.e.\ $-10log_{10}$ prob(call in ALT is wrong).
@@ -876,6 +877,7 @@ VCF STRUCTURAL VARIANT EXAMPLE
 \normalsize
 
 \subsection{Specifying complex rearrangements with breakends}
+\label{Breakends}
 
 An arbitrary rearrangement event can be summarized as a set of novel \textbf{adjacencies}. Each adjacency ties together $2$ \textbf{breakends}.
 The two breakends at either end of a novel adjacency are called \textbf{mates}.


### PR DESCRIPTION
This PR aims to clarify some points discussed in #437 :

- `*` is a complete allele. It must not be mixed with other ACTG bases.
- Genotypes are meant to be deltas: changes from the reference sequence. Thus, a sample may have a genotype 0 that contradicts another record. Genotype 0 means "no change unless other records say so".

This approach is controversial as can be seen in the issue, but the disadvantages look less important than the following points:
- The notation with base-`*` is more explicit and sometimes clearer but imposes a record interdependency that is not really aligned with VCF in terms of record filtering or VCF merging.
- Following on this independence of records, the genotype 0 has been historically understood by a big part of the community and tools as "this record reports no change for this sample".


---
There are some points (raised in the issue) that should be addressed before merging this PR:

- Should we explicitly say that a "true reference" can not be stated in VCF? or should we explicitly explain a way to state a "true reference" with the REF-only blocks? (I'm not sure how the latter can be done)
- Should we keep `*` as overlapping *deletion*? with the above definition of genotype 0, changing `*` to be overlapping *allele* would be redundant. I favour keeping as overlapping deletion even if just for the sake of avoiding having multiple ways to do the same.
- this PR only changes 4.3, which is what I think was agreed regarding version handling, where we try not to modify old versions except in critical cases, but the clarification of genotype 0 looks a bit critical to me. 

