### PR TITLE
Improved Structural Variant Support

### DIFF
--- a/VCFv4.3.tex
+++ b/VCFv4.3.tex
@@ -585,14 +585,14 @@ For precise variants, END is $\mbox{POS} + \mbox{length of REF allele} - 1$, and
 \end{samepage}
 SVTYPE is a primitive basic data type and must be specified for all structural variants.
 Its value can usually be deduced from the REF and ALT fields, however despite this redundancy it is quite useful for filtering.
-For each VCF record, SVTYPE must be assigned exactly one of the following values:
+For each VCF record encoding a symbolic structural variant, SVTYPE must be assigned exactly one of the following values:
 \begin{itemize}
 \item DEL: Deletion relative to the reference
 \item INS: Insertion relative to the reference
-\item DUP: Region of elevated copy number relative to the reference
+\item DUP: Tandem duplication relative to the reference
 \item INV: Inversion of reference sequence
 \item CNV: Copy number variable region (multiallelic)
-\item BND: Breakend
+\item BND: Breakpoint or single breakend
 \end{itemize}
 
 \footnotesize
@@ -837,60 +837,6 @@ $2$ & \verb|a t c G C G C G a| & following the G base is an insertion of 2 bases
 \end{tabular}
 
 \subsection{Encoding Structural Variants}
-The following page contains examples of structural variants encoded in VCF, showing in order:
-\begin{enumerate}
-  \item A precise deletion with known breakpoint, a one base micro-homology, and a sample that is homozygous for the deletion.
-  \item An imprecise deletion of approximately 205 bp.
-  \item An imprecise deletion of an ALU element relative to the reference.
-  \item An imprecise insertion of an L1 element relative to the reference.
-  \item An imprecise duplication of approximately 21Kb. The sample genotype is copy number 3 (one extra copy of the duplicated sequence).
-  \item An imprecise tandem duplication of 76bp. The sample genotype is copy number 5 (but the two haplotypes are not known).
-\end{enumerate}
-
-\pagebreak
-\footnotesize
-\begin{landscape}
-\begin{verbatim}
-VCF STRUCTURAL VARIANT EXAMPLE
-
-##fileformat=VCFv4.3
-##fileDate=20180101
-##reference=GRCh38.p11
-##assembly=ftp://ftp-trace.ncbi.nih.gov/1000genomes/ftp/release/sv/breakpoint_assemblies.fasta
-##INFO=<ID=BKPTID,Number=.,Type=String,Description="ID of the assembled alternate allele in the assembly file">
-##INFO=<ID=CIEND,Number=2,Type=Integer,Description="Confidence interval around END for imprecise variants">
-##INFO=<ID=CIPOS,Number=2,Type=Integer,Description="Confidence interval around POS for imprecise variants">
-##INFO=<ID=END,Number=1,Type=Integer,Description="End position of the variant described in this record">
-##INFO=<ID=HOMLEN,Number=.,Type=Integer,Description="Length of base pair identical micro-homology at event breakpoints">
-##INFO=<ID=HOMSEQ,Number=.,Type=String,Description="Sequence of base pair identical micro-homology at event breakpoints">
-##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Difference in length between REF and ALT alleles">
-##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
-##ALT=<ID=DEL,Description="Deletion">
-##ALT=<ID=DEL:ME:ALU,Description="Deletion of ALU element">
-##ALT=<ID=DEL:ME:L1,Description="Deletion of L1 element">
-##ALT=<ID=DUP,Description="Duplication">
-##ALT=<ID=DUP:TANDEM,Description="Tandem Duplication">
-##ALT=<ID=INS,Description="Insertion of novel sequence">
-##ALT=<ID=INS:ME:ALU,Description="Insertion of ALU element">
-##ALT=<ID=INS:ME:L1,Description="Insertion of L1 element">
-##ALT=<ID=INV,Description="Inversion">
-##ALT=<ID=CNV,Description="Copy number variable region">
-##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
-##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="Genotype quality">
-##FORMAT=<ID=CN,Number=1,Type=Integer,Description="Copy number genotype for imprecise events">
-##FORMAT=<ID=CNQ,Number=1,Type=Float,Description="Copy number genotype quality for imprecise events">
-#CHROM POS     ID        REF              ALT          QUAL FILTER INFO                                                               FORMAT       NA00001
-1      2827694 rs2376870 CGTGGATGCGGGGAC  C            .    PASS   SVTYPE=DEL;END=2827708;HOMLEN=1;HOMSEQ=G;SVLEN=-14                 GT:GQ        1/1:14
-2       321682 .         T                <DEL>        6    PASS   SVTYPE=DEL;END=321887;SVLEN=-205;CIPOS=-56,20;CIEND=-10,62         GT:GQ        0/1:12
-2     14477084 .         C                <DEL:ME:ALU> 12   PASS   SVTYPE=DEL;END=14477381;SVLEN=-297;CIPOS=-22,18;CIEND=-12,32       GT:GQ        0/1:12
-3      9425916 .         C                <INS:ME:L1>  23   PASS   SVTYPE=INS;END=9425916;SVLEN=6027;CIPOS=-16,22                     GT:GQ        1/1:15
-3     12665100 .         A                <DUP>        14   PASS   SVTYPE=DUP;END=12686200;SVLEN=21100;CIPOS=-500,500;CIEND=-500,500  GT:GQ:CN:CNQ ./.:0:3:16.2
-4     18665128 .         T                <DUP:TANDEM> 11   PASS   SVTYPE=DUP;END=18665204;SVLEN=76;CIPOS=-10,10;CIEND=-10,10         GT:GQ:CN:CNQ ./.:0:5:8.3
-\end{verbatim}
-\end{landscape}
-\pagebreak
-\normalsize
-
 \subsection{Specifying complex rearrangements with breakends}
 
 An arbitrary rearrangement event can be summarized as a set of novel \textbf{adjacencies}. Each adjacency ties together $2$ \textbf{breakends}.
@@ -1415,6 +1361,191 @@ Example records are given below:
 \end{tabular}
 \end{flushleft}
 \normalsize
+\pagebreak
+
+\subsection{Structural Variants Examples}
+
+As with non-structural variants, there are multiple equivalent way to encode a structural variant.
+This section contains examples of the formats for which a structural variant can be encoded in VCF.
+
+\subsubsection{Simple Structural Variants}
+The following page contains examples of structural variants encoded in VCF, showing in order:
+\begin{enumerate}
+  \item A precise deletion with known breakpoint, a one base micro-homology, and a sample that is homozygous for the deletion.
+  \item An imprecise deletion of approximately 205 bp.
+  \item An imprecise deletion of an ALU element relative to the reference.
+  \item An imprecise insertion of an L1 element relative to the reference.
+  \item An imprecise duplication of approximately 21Kb. The sample genotype is copy number 3 (one extra copy of the duplicated sequence).
+  \item An imprecise tandem duplication of 76bp. The sample genotype is copy number 5 (but the two haplotypes are not known).
+\end{enumerate}
+
+\pagebreak
+\footnotesize
+\begin{landscape}
+\begin{verbatim}
+##fileformat=VCFv4.3
+##fileDate=20180101
+##reference=GRCh38.p11
+##assembly=ftp://ftp-trace.ncbi.nih.gov/1000genomes/ftp/release/sv/breakpoint_assemblies.fasta
+##INFO=<ID=BKPTID,Number=.,Type=String,Description="ID of the assembled alternate allele in the assembly file">
+##INFO=<ID=CIEND,Number=2,Type=Integer,Description="Confidence interval around END for imprecise variants">
+##INFO=<ID=CIPOS,Number=2,Type=Integer,Description="Confidence interval around POS for imprecise variants">
+##INFO=<ID=END,Number=1,Type=Integer,Description="End position of the variant described in this record">
+##INFO=<ID=HOMLEN,Number=.,Type=Integer,Description="Length of base pair identical micro-homology at event breakpoints">
+##INFO=<ID=HOMSEQ,Number=.,Type=String,Description="Sequence of base pair identical micro-homology at event breakpoints">
+##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Difference in length between REF and ALT alleles">
+##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
+##ALT=<ID=DEL,Description="Deletion">
+##ALT=<ID=DEL:ME:ALU,Description="Deletion of ALU element">
+##ALT=<ID=DEL:ME:L1,Description="Deletion of L1 element">
+##ALT=<ID=DUP,Description="Duplication">
+##ALT=<ID=DUP:TANDEM,Description="Tandem Duplication">
+##ALT=<ID=INS,Description="Insertion of novel sequence">
+##ALT=<ID=INS:ME:ALU,Description="Insertion of ALU element">
+##ALT=<ID=INS:ME:L1,Description="Insertion of L1 element">
+##ALT=<ID=INV,Description="Inversion">
+##ALT=<ID=CNV,Description="Copy number variable region">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="Genotype quality">
+##FORMAT=<ID=CN,Number=1,Type=Integer,Description="Copy number genotype for imprecise events">
+##FORMAT=<ID=CNQ,Number=1,Type=Float,Description="Copy number genotype quality for imprecise events">
+#CHROM POS     ID        REF              ALT          QUAL FILTER INFO                                                               FORMAT       NA00001
+1      2827694 rs2376870 CGTGGATGCGGGGAC  C            .    PASS   SVTYPE=DEL;END=2827708;HOMLEN=1;HOMSEQ=G;SVLEN=-14                 GT:GQ        1/1:14
+2       321682 .         T                <DEL>        6    PASS   SVTYPE=DEL;END=321887;SVLEN=-205;CIPOS=-56,20;CIEND=-10,62         GT:GQ        0/1:12
+2     14477084 .         C                <DEL:ME:ALU> 12   PASS   SVTYPE=DEL;END=14477381;SVLEN=-297;CIPOS=-22,18;CIEND=-12,32       GT:GQ        0/1:12
+3      9425916 .         C                <INS:ME:L1>  23   PASS   SVTYPE=INS;END=9425916;SVLEN=6027;CIPOS=-16,22                     GT:GQ        1/1:15
+3     12665100 .         A                <DUP>        14   PASS   SVTYPE=DUP;END=12686200;SVLEN=21100;CIPOS=-500,500;CIEND=-500,500  GT:GQ:CN:CNQ ./.:0:3:16.2
+4     18665128 .         T                <DUP:TANDEM> 11   PASS   SVTYPE=DUP;END=18665204;SVLEN=76;CIPOS=-10,10;CIEND=-10,10         GT:GQ:CN:CNQ ./.:0:5:8.3
+\end{verbatim}
+\end{landscape}
+\pagebreak
+\normalsize
+
+\subsubsection{Equivalent Deletions}
+
+A 5bp deletion of the following form:
+
+\begin{verbatim}
+1234567890 position
+ATAGGTTCGC reference contig
+AT-----CGC variant
+\end{verbatim}
+
+\begin{verbatim}
+#CHROM    POS  ID          REF     ALT         QUAL FILTER INFO
+contig    2    del_indel   TAGGTT  T           .    .
+contig    2    del_indel2  TAGGTTC TC          .    .
+contig    1    del_indel3  ATAGGTT AT          .    .
+contig    3    del_indel4  AGGTTC  C           .    .
+contig    3    del_svtype  A       <DEL>       .    .      SVTYPE=DEL;SVLEN=-5;END=7
+contig    2    del_bnd_1   T       T[contig:8[ .    .      SVTYPE=BND;PARID=del_bnd_2
+contig    8    del_bnd_2   C       ]contig:2]C .    .      SVTYPE=BND;PARID=del_bnd_1
+\end{verbatim}
+
+By convention, only the reference base immediately preceding the deletion is reported.
+This makes $del\_indel$ preferable to $del\_indel2$, $del\_indel3$, or $del\_indel4$.
+
+$del\_bnd1$/$del\_bnd2$ are making a claim only about the presence of the breakpoint, not the copy number of the 'deleted' region.
+It is possible that this breakpoint forms part of a complex rearrangement and the 'deleted' is still present, in another location.
+
+\subsubsection{Equivalent Insertions}
+
+A 5bp insertion (CTCAG) of the following form:
+
+\begin{verbatim}
+123-----4567890 position
+ATA-----GGTTCGC reference contig
+ATACTCAGGGTTCGC variant
+\end{verbatim}
+
+Assuming a file $path\_to\_fasta\_containing\_asm.fasta$ contains the following:
+\begin{verbatim}
+>asm
+ACTCAG
+\end{verbatim}
+
+Then the following records all encode the same insertion:
+
+\begin{verbatim}
+##assembly=path_to_fasta_containing_asm.fasta
+#CHROM    POS  ID                         REF    ALT              QUAL FILTER INFO
+contig    3    ins_indel_representation1  A      ACTCAG           .    .    
+contig    4    ins_indel_representation2  G      CTCAGG           .    .    
+contig    3    ins_svtype_representation1 A      <INS>            .    .      SVTYPE=INS;SVLEN=5;END=3
+contig    4    ins_svtype_representation2 G      <INS>            .    .      SVTYPE=INS;SVLEN=5;END=4
+contig    3    ins_bnd_1                  A      ACTCAG[contig:4[ .    .      SVTYPE=BND;PARID=ins_bnd_2
+contig    4    ins_bnd_2                  G      ]contig:3]CTCAGG .    .      SVTYPE=BND;PARID=ins_bnd_1
+contig    4    ins_asm_full               G      <asm>            .    .      BKPTID=asm
+contig    3    ins_asm_1                  A      A[<asm>:2[       .    .      SVTYPE=BND;PARID=ins_asm_2
+contig    4    ins_asm_2                  G      ]<asm>:6]G       .    .      SVTYPE=BND;PARID=ins_asm_1
+\end{verbatim}
+
+Note the following:
+\begin{itemize}
+	\item The $indel$ and $svtype$ representations 1 and 2 corresponding to using the preceding and succeeding reference base respectively.
+	By convention, the preceding base is used as the anchor.
+	\item $ins\_svtype\_representation1$ and $ins\_svtype\_representation2$ are lossy representation as they do not include the inserted sequence.
+	\item $ins\_asm\_*$ require the external fasta file to reconstruct the variant.
+	\item $ins\_asm\_1$ starts at base 2 of the asm contig as $ins\_asm\_full$ encodes the ALT allele relative to the REF, and the REF includes the anchoring base.
+\end{itemize}
+\subsubsection{Equivalent Tandem Duplications}
+
+A 5bp tandem duplication (AGGTT) of the following form:
+
+\begin{verbatim}
+12-----34567890
+AT-----AGGTTCGC
+ATAGGTTCGGTTCGC
+\end{verbatim}
+
+\begin{verbatim}
+#CHROM    POS  ID                 REF    ALT          QUAL FILTER INFO
+contig    4    dup_indel_verbose  GGTTC  GGTTCGGTTC   .    .    
+contig    8    dup_indel_minimal  C      CGGTTC       .    .    
+contig    9    dup_indel_minimal2 C      GGTTCG       .    .    
+contig    4    dup_svtype         G      <DUP:TANDEM> .    .      SVTYPE=DUP;SVLEN=5;END=8
+contig    4    dup_bnd_1          G      ]contig:8]G  .    .      SVTYPE=BND;PARID=dup_bnd_2
+contig    8    dup_bnd_2          C      C[contig:4[  .    .      SVTYPE=BND;PARID=dup_bnd_1
+\end{verbatim}
+
+$dup\_bnd1$/$dup\_bnd2$ are making a claim only about the presence of the breakpoint, not the copy number of the 'duplication' region.
+It is possible that this breakpoint forms part of a complex rearrangement and the 'duplicated' region does not have elevated copy number.
+
+\subsubsection{Equivalent Inversions}
+
+A 4bp inversion of the following form:
+
+\begin{verbatim}
+1234567890
+ATAGGTTCGC
+ATAAACCCGC
+   ----
+\end{verbatim}
+
+\begin{verbatim}
+#CHROM    POS  ID         REF      ALT         QUAL FILTER INFO
+contig    4    inv_indel  GGTT     AACC        .    .    
+contig    4    inv_indel  AGGTT    AAACC       .    .    
+contig    4    inv_svtype G        <INV>       .    .      SVTYPE=INV;SVLEN=0;END=7
+contig    3    inv_bnd_1  A        A]contig:7] .    .      SVTYPE=BND;PARID=ins_bnd_2;EVENT=example_inv
+contig    7    inv_bnd_2  T        T]contig:3] .    .      SVTYPE=BND;PARID=ins_bnd_1;EVENT=example_inv
+contig    4    inv_bnd_3  G        [contig:8[G .    .      SVTYPE=BND;PARID=ins_bnd_4;EVENT=example_inv
+contig    8    inv_bnd_4  C        [contig:4[C .    .      SVTYPE=BND;PARID=ins_bnd_3;EVENT=example_inv
+\end{verbatim}
+
+\subsubsection{Copy Number Variants}
+
+Some methods identify changes in copy number.
+In such situations, SVTYPE should be specified as CNV as such methods do not make breakpoint claims.
+The deletion and duplication examples outlined above would be represented as follows:
+
+\begin{verbatim}
+#CHROM    POS    ID          REF    ALT    QUAL FILTER INFO
+contig    3      del_cnv     A      <DEL>  .    .      SVTYPE=CNV;SVLEN=-5;END=7
+contig    4      dup_cnv     G      <DUP>  .    .      SVTYPE=CNV;SVLEN=5;END=8
+\end{verbatim}
+
+Note that the ALT is specified as <DUP>, not <DUP:TANDEM>, as the location of the additional copy is not known.
 
 \pagebreak
 \section{BCF specification}

--- a/VCFv4.3.tex
+++ b/VCFv4.3.tex
@@ -173,30 +173,53 @@ Genotype fields specified in the FORMAT field are described as follows:
 Possible Types for FORMAT fields are: Integer, Float, Character, and String (this field is otherwise defined precisely as the INFO field).
 
 \subsubsection{Alternative allele field format}
-Symbolic alternate alleles are described as follows:
+Symbolic alternate alleles specified in the ALT field are described as follows:
 \begin{verbatim}
 ##ALT=<ID=type,Description=description>
 \end{verbatim}
 
 \noindent \textbf{Structural Variants} \newline
-In symbolic alternate alleles for imprecise structural variants, the ID field indicates the type of structural variant, and can be a colon-separated list of types and subtypes.
-ID values are case sensitive strings and must not contain whitespace or angle brackets.
-The first level type must be one of the following:
-\begin{itemize}
-  \item DEL Deletion relative to the reference
-  \item INS Insertion of novel sequence relative to the reference
-  \item DUP Region of elevated copy number relative to the reference
-  \item INV Inversion of reference sequence
-  \item CNV Copy number variable region (may be both deletion and duplication)
-  \item BND Breakend
-\end{itemize}
 
-The CNV category should not be used when a more specific category can be applied. Reserved subtypes include:
-\begin{itemize}
-  \item DUP:TANDEM Tandem duplication
-  \item DEL:ME Deletion of mobile element relative to the reference
-  \item INS:ME Insertion of a mobile element relative to the reference
-\end{itemize}
+
+\begin{tabular}{l l}
+DEL  &  Deletion relative to the reference \\
+INS  &  Insertion relative to the reference \\
+DUP  &  Region of elevated copy number relative to the reference \\
+INV  &  Inversion of reference sequence \\
+CNV  &  Copy number variable region (multiallelic) \\
+BND  &  Breakend \\
+\end{tabular}\newline
+
+\noindent The list of first level symbolic alleles that represent structural variants is a closed set. Any symbolic alleles with a first level type other than one of those listed above are considered to be non-structural symbolic alleles.\newline
+
+\noindent Variant subtypes should be used to add specificity to the maximum extent supported by the data. Reserved subtypes include:
+\newline
+
+\begin{tabular}{l l}
+DEL:ME  &  Absence of mobile element present in the reference \\
+DEL:ME:ALU  &  Absence of Alu element present in the reference \\
+DEL:ME:LINE1  &  Absence of LINE1 element present in the reference \\
+DEL:ME:SVA  &  Absence of SVA element present in the reference \\
+DEL:ME:HERV  &  Absence of HERV element present in the reference \\
+\\
+INS:ME  &  Insertion of mobile element relative to the reference \\
+INS:ME:ALU  &  Insertion of Alu element relative to the reference \\
+INS:ME:LINE1  &  Insertion of LINE1 element relative to the reference \\
+INS:ME:SVA  &  Insertion of SVA element relative to the reference \\
+INS:ME:HERV  &  Insertion of HERV element relative to the reference \\
+\\
+DUP:TANDEM  &  Tandem duplication, in same orientation as original \\
+DUP:INV-BEFORE  &  Tandem duplication, inserted before original in inverted orientation \\
+DUP:INV-AFTER  &  Tandem duplication, inserted after original in inverted orientation \\
+\end{tabular}\newline \newline
+
+\noindent Variants should be written using the most precise type that can be determined by the variant caller. For example, if the insertion site of a new copy of a LINE1 element cannot be determined, it would be specified as a DUP of the originating LINE1 element. However if the new insertion site can be identified, the variant should be specified as INS:ME:LINE1 at the insertion site.\newline
+
+\noindent Note that the DUP type is not restricted to tandem duplications and that the DUP subtypes have different breakpoints than their parent type.\newline
+
+\noindent Variant subtypes are an open set and is it valid for a variant caller to define a subtype not specified in the above list. Such subtypes are considered to be instances of the first reserved subtype, with breakpoint and copy number semantics matching the reserved type. For example, INS:ME:PELEMENT is a valid caller-defined subtype, but INV:FOLDBACK is not since foldback inversions do not result in the same breakpoint and copy number changes as a simple inversion.\newline
+
+\noindent See examples below for further guidance.
 
 \bigskip
 
@@ -563,15 +586,14 @@ For precise variants, END is $\mbox{POS} + \mbox{length of REF allele} - 1$, and
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
 \end{verbatim}
 \normalsize
-\end{samepage}
-This key can be derived from the REF/ALT fields but is useful for filtering.
-The reserved values must be used for the types listed below:
+SVTYPE is a primitive basic data type and must be specified for all structural variants. Its value can usually be deduced from the REF and ALT fields, however despite this redundancy it is quite useful for filtering. For each VCF record, SVTYPE must be assigned exactly one of the following values:
 \begin{itemize}
   \item DEL: Deletion relative to the reference
-  \item INS: Insertion of novel sequence relative to the reference
+\item INS:  Insertion relative to the reference
   \item DUP: Region of elevated copy number relative to the reference
   \item INV: Inversion of reference sequence
-  \item CNV: Copy number variable region (may be both deletion and duplication)
+\item CNV:  Copy number variable region (multiallelic)
+\item BND:  Breakend
   \item BND: Breakend
 \end{itemize}
 
@@ -580,7 +602,13 @@ The reserved values must be used for the types listed below:
 ##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Difference in length between REF and ALT alleles">
 \end{verbatim}
 \normalsize
-One value for each ALT allele. Longer ALT alleles (e.g.\ insertions) have positive values, shorter ALT alleles (e.g.\ deletions) have negative values.
+SVLEN indicates the relative size of the ALT allele compared to the REF allele.\
+If ALT is longer than REF (e.g. insertions), SVLEN must be positive; if ALT is shorter than REF (e.g. deletions), SVLEN must be negative.
+Simple inversions will have SVLEN=0.
+The size of the inversion can be determined by the POS field and the END attribute.
+One SVLEN value for each ALT allele.
+One value for each ALT allele.
+Longer ALT alleles (e.g.\ insertions) have positive values, shorter ALT alleles (e.g.\ deletions) have negative values.
 
 \footnotesize
 \begin{verbatim}
@@ -830,8 +858,8 @@ The following page contains examples of structural variants encoded in VCF, show
 VCF STRUCTURAL VARIANT EXAMPLE
 
 ##fileformat=VCFv4.3
-##fileDate=20100501
-##reference=1000GenomesPilot-NCBI36
+##fileDate=20180101
+##reference=GRCh38.p11
 ##assembly=ftp://ftp-trace.ncbi.nih.gov/1000genomes/ftp/release/sv/breakpoint_assemblies.fasta
 ##INFO=<ID=BKPTID,Number=.,Type=String,Description="ID of the assembled alternate allele in the assembly file">
 ##INFO=<ID=CIEND,Number=2,Type=Integer,Description="Confidence interval around END for imprecise variants">

--- a/VCFv4.3.tex
+++ b/VCFv4.3.tex
@@ -184,9 +184,9 @@ Symbolic alternate alleles specified in the ALT field are described as follows:
 \begin{tabular}{l l}
 DEL  &  Deletion relative to the reference \\
 INS  &  Insertion relative to the reference \\
-DUP  &  Region of elevated copy number relative to the reference \\
+DUP  &  Tandem duplication relative to the reference \\
 INV  &  Inversion of reference sequence \\
-CNV  &  Copy number variable region (multiallelic) \\
+CNV  &  Copy number variable region \\
 BND  &  Breakend \\
 \end{tabular}\newline
 
@@ -207,15 +207,11 @@ INS:ME:ALU  &  Insertion of Alu element relative to the reference \\
 INS:ME:LINE1  &  Insertion of LINE1 element relative to the reference \\
 INS:ME:SVA  &  Insertion of SVA element relative to the reference \\
 INS:ME:HERV  &  Insertion of HERV element relative to the reference \\
-\\
-DUP:TANDEM  &  Tandem duplication, in same orientation as original \\
-DUP:INV-BEFORE  &  Tandem duplication, inserted before original in inverted orientation \\
-DUP:INV-AFTER  &  Tandem duplication, inserted after original in inverted orientation \\
 \end{tabular}\newline \newline
 
 \noindent Variants should be written using the most precise type that can be determined by the variant caller. For example, if the insertion site of a new copy of a LINE1 element cannot be determined, it would be specified as a DUP of the originating LINE1 element. However if the new insertion site can be identified, the variant should be specified as INS:ME:LINE1 at the insertion site.\newline
 
-\noindent Note that the DUP type is not restricted to tandem duplications and that the DUP subtypes have different breakpoints than their parent type.\newline
+\noindent Note that the DUP type is restricted to simple tandem duplications. More complex duplications should be specified using BND notation.\newline
 
 \noindent Variant subtypes are an open set and it is valid for a variant caller to define a subtype not specified in the above list. Such subtypes are considered to be instances of the first reserved subtype, with breakpoint and copy number semantics matching the reserved type. For example, INS:ME:PELEMENT is a valid caller-defined subtype, but INV:FOLDBACK is not since foldback inversions do not result in the same breakpoint and copy number changes as a simple inversion.\newline
 

--- a/VCFv4.3.tex
+++ b/VCFv4.3.tex
@@ -2102,6 +2102,9 @@ Therefore, also \#\#PEDIGREE newly requires a unique ID.
 \item Chromosome names cannot use reserved symbolic alleles and contain characters used by breakpoints (Section~\ref{sec-contig-field}).
 \item IUPAC ambiguity codes should be converted to a concrete base.
 \item Symbolic ALTs for IUPAC codes.
+\item Made SVTYPE mandatory for SVs.
+\item Top-level SVTYPE values are explicitly restricted to the 6 defined in the specifications.
+\item Reserved some SVTYPE subtypes.
 \end{itemize}
 
 \subsection{Changes between BCFv2.1 and BCFv2.2}

--- a/VCFv4.3.tex
+++ b/VCFv4.3.tex
@@ -217,7 +217,7 @@ DUP:INV-AFTER  &  Tandem duplication, inserted after original in inverted orient
 
 \noindent Note that the DUP type is not restricted to tandem duplications and that the DUP subtypes have different breakpoints than their parent type.\newline
 
-\noindent Variant subtypes are an open set and is it valid for a variant caller to define a subtype not specified in the above list. Such subtypes are considered to be instances of the first reserved subtype, with breakpoint and copy number semantics matching the reserved type. For example, INS:ME:PELEMENT is a valid caller-defined subtype, but INV:FOLDBACK is not since foldback inversions do not result in the same breakpoint and copy number changes as a simple inversion.\newline
+\noindent Variant subtypes are an open set and it is valid for a variant caller to define a subtype not specified in the above list. Such subtypes are considered to be instances of the first reserved subtype, with breakpoint and copy number semantics matching the reserved type. For example, INS:ME:PELEMENT is a valid caller-defined subtype, but INV:FOLDBACK is not since foldback inversions do not result in the same breakpoint and copy number changes as a simple inversion.\newline
 
 \noindent See examples below for further guidance.
 
@@ -603,7 +603,7 @@ SVTYPE is a primitive basic data type and must be specified for all structural v
 \end{verbatim}
 \normalsize
 SVLEN indicates the relative size of the ALT allele compared to the REF allele.\
-If ALT is longer than REF (e.g. insertions), SVLEN must be positive; if ALT is shorter than REF (e.g. deletions), SVLEN must be negative.
+If ALT is longer than REF (e.g.\ insertions), SVLEN must be positive; if ALT is shorter than REF (e.g.\ deletions), SVLEN must be negative.
 Simple inversions will have SVLEN=0.
 The size of the inversion can be determined by the POS field and the END attribute.
 One SVLEN value for each ALT allele.

--- a/VCFv4.3.tex
+++ b/VCFv4.3.tex
@@ -586,15 +586,17 @@ For precise variants, END is $\mbox{POS} + \mbox{length of REF allele} - 1$, and
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
 \end{verbatim}
 \normalsize
-SVTYPE is a primitive basic data type and must be specified for all structural variants. Its value can usually be deduced from the REF and ALT fields, however despite this redundancy it is quite useful for filtering. For each VCF record, SVTYPE must be assigned exactly one of the following values:
+\end{samepage}
+SVTYPE is a primitive basic data type and must be specified for all structural variants.
+Its value can usually be deduced from the REF and ALT fields, however despite this redundancy it is quite useful for filtering.
+For each VCF record, SVTYPE must be assigned exactly one of the following values:
 \begin{itemize}
-  \item DEL: Deletion relative to the reference
-\item INS:  Insertion relative to the reference
-  \item DUP: Region of elevated copy number relative to the reference
-  \item INV: Inversion of reference sequence
-\item CNV:  Copy number variable region (multiallelic)
-\item BND:  Breakend
-  \item BND: Breakend
+\item DEL: Deletion relative to the reference
+\item INS: Insertion relative to the reference
+\item DUP: Region of elevated copy number relative to the reference
+\item INV: Inversion of reference sequence
+\item CNV: Copy number variable region (multiallelic)
+\item BND: Breakend
 \end{itemize}
 
 \footnotesize
@@ -607,8 +609,6 @@ If ALT is longer than REF (e.g.\ insertions), SVLEN must be positive; if ALT is 
 Simple inversions will have SVLEN=0.
 The size of the inversion can be determined by the POS field and the END attribute.
 One SVLEN value for each ALT allele.
-One value for each ALT allele.
-Longer ALT alleles (e.g.\ insertions) have positive values, shorter ALT alleles (e.g.\ deletions) have negative values.
 
 \footnotesize
 \begin{verbatim}


### PR DESCRIPTION
Various drafts of improved Structural Variant support have been floating around for 2.5 years (see #231, #266) but never merged. I'm attempting to collate everything together in this PR but it is unclear as to what is in scope.

The following changes were agreed backed in 2017 by Cristina Yenyxe Gonzalez, Steve Huang, Daniel Cameron, Xuefang Zhao, Tobias Rausch, Tim Hefferon, John Lopez, Chris Whelan:

- Restrict SVTYPE to the 6 primitives
  - SVTYPE will be re-cast as a "basic primitive"; its distinction from EVENTTYPE will be made clear in the spec
  - SVTYPE will have the following closed controlled vocabulary: DEL, INS, DUP, INV, CNV, BND
  - No colons or subtypes are allowed in SVTYPE value
  - All SV VCF records must include a value for SVTYPE
- EVENTTYPE will be added to the spec. It will contain the "biological interpretation" of the variant
   - EVENTTYPE will have an open controlled vocabulary, to include: INS, MEI, ALU, L1, SVA, HERV, DEL, -MEI-, -ALU-, -L1-, -SVA-, -HERV-, INV, DUP, DELINS, CNV
- EVENT will continue to be used to specify identifiers to link together multiple VCF records
  - EVENT is currently discussed primarily in the graphical BND-notation section of the spec; text will be added elsewhere, in relevant context area(s) of the spec.
- CIPOS and CIEND will continue to be used as they have in the past: as the primary means of representing an interval within which a breakpoint is likely to fall.
  - The spec will be amended with examples, as needed, to illustrate the preferred usage of CIPOS and CIEND.
- New tags CIPOSPROB and CIENDPROB will be introduced to the spec as a means to indicate the level of confidence implied by CIPOS and CIEND, respectively.
  - Each CI*PROB value shall contain two (2) values separated by a comma. These values shall represent the proportion of a normal distribution expected to fall outside the values recorded in CIPOS. For example, CIPOS=(-50,100) and CIPOSPROB=(0,0.95) indicate the probability that the breakpoint lay more than 50 bp to the left of POS is zero, and the probability that it lay more than 100bp to the right of POS os 0.95.
- New tag HOMPOS will be introduced to the spec. Its value shall represent the coordinate on the given contig of the first basepair of the microhomology indicated by HOMSEQ.
  - The definition of HOMPOS will be: Position (relative to POS) of base pair identical micro-homology around event breakpoint. Note that length(HOMSEQ)=HOMLEN=HOMPOS[1]-HOMPOS[0]
- BND will be officially added to the SVTYPE controlled vocabulary, and it will be referenced consistently throughout the spec (unlike now). It will NOT be replaced by other terms that were discussed, such as TRA (for translocation) or ADJ (for adjacency).
- Examples of each type of event shall be drawn up and added to the spec, including one in "standard" notation and another in the equivalent "BND" notation. Tim and Daniel will draft these examples, respectively.




Additional changes that I'd like to see are:
- Either 1 SV per record, or SV fields counts standardised to handle multiple SV records
  - the latter was blocked by VCF not supporting list of lists
- A field to resolve STR expansion ambiguity (e.g. HOMSTRIDE)
- Sub-clonality support (for all variants)
- genotyping support for somatic SVs. There are two issues with the current specs: 
  - copy number != ploidy
  - maternal/paternal haplotypes are still meaningful for somatic SV, it's just that there can be many copies of each.
- Karyotype reconstruction
  - a 'next SV' field is sufficient
  - PSL could be adapted to handle this
- Explicit clarification around SVTYPE about what the claim is
  - currently both CNV and SV callers write DELs so it's unclear if a DEL is claim of a breakpoint adjacency, a segmental loss, or both


@lbergelson @yfarjoun @pd3 What's the best way forward from here that minimises the chances of us sitting on PRs for another 2 years?
