### PR TITLE
Show double quotes around ##ALT Description

### DIFF
--- a/VCFv4.1.tex
+++ b/VCFv4.1.tex
@@ -89,7 +89,7 @@ Possible Types for FORMAT fields are: Integer, Float, Character, and String (thi
 Symbolic alternate alleles for imprecise structural variants:
 
 \begin{verbatim}
-##ALT=<ID=type,Description=description>
+##ALT=<ID=type,Description="description">
 \end{verbatim}
 The ID field indicates the type of structural variant, and can be a colon-separated list of types and subtypes. ID values are case sensitive strings and may not contain whitespace or angle brackets. The first level type must be one of the following:
 \begin{itemize}

--- a/VCFv4.2.tex
+++ b/VCFv4.2.tex
@@ -98,7 +98,7 @@ Possible Types for FORMAT fields are: Integer, Float, Character, and String (thi
 Symbolic alternate alleles for imprecise structural variants:
 
 \begin{verbatim}
-##ALT=<ID=type,Description=description>
+##ALT=<ID=type,Description="description">
 \end{verbatim}
 The ID field indicates the type of structural variant, and can be a colon-separated list of types and subtypes. ID values are case sensitive strings and may not contain whitespace or angle brackets. The first level type must be one of the following:
 \begin{itemize}

--- a/VCFv4.3.tex
+++ b/VCFv4.3.tex
@@ -175,7 +175,7 @@ Possible Types for FORMAT fields are: Integer, Float, Character, and String (thi
 \subsubsection{Alternative allele field format}
 Symbolic alternate alleles are described as follows:
 \begin{verbatim}
-##ALT=<ID=type,Description=description>
+##ALT=<ID=type,Description="description">
 \end{verbatim}
 
 \noindent \textbf{Structural Variants} \newline


### PR DESCRIPTION
Unlike for the other headers, the section on `##ALT` does not show the `Description` field as having double quotes around it.

However §1.4.2 (Information field format) says Description must be surrounded by double-quotes and this can be construed as applying to Descriptions in all headers, all the other headers show it, all the examples of `##ALT` in the specification have double quotes, and tools such as bcftools and GATK use double quotes in the `##ALT` fields they output. So this is presumably just an omission in the spec.

Hat tip @lltw; see pysam-developers/pysam#881.