### PR TITLE
Adding PP tag to vcf 4.3 spec.

### DIFF
--- a/VCFv4.3.tex
+++ b/VCFv4.3.tex
@@ -425,6 +425,7 @@ See also Section~\ref{sv-format-keys} for a list of genotype keys reserved for s
       HQ		& 2		& Integer	& Haplotype quality \\
       MQ		& 1		& Integer	& RMS mapping quality \\
       PL		& G		& Integer	& Phred-scaled genotype likelihoods rounded to the closest integer \\
+      PP		& G		& Integer	& Phred-scaled genotype posterior probabilities rounded to the closest integer \\
       PQ		& 1		& Integer	& Phasing quality \\
       PS		& 1		& Integer	& Phase set \\
 \end{longtable}
@@ -511,7 +512,8 @@ See also Section~\ref{sv-format-keys} for a list of genotype keys reserved for s
 
   \item HQ (Integer): Haplotype qualities, two comma separated phred qualities.
   \item MQ (Integer): RMS mapping quality, similar to the version in the INFO field.
-  \item PL (Integer): The phred-scaled genotype likelihoods rounded to the closest integer, and otherwise defined precisely as the GL field.
+  \item PL (Integer): The phred-scaled genotype likelihoods rounded to the closest integer, and otherwise defined in the same way as the GL field.
+  \item PP (Integer): The phred-scaled genotype posterior probabilities rounded to the closest integer, and otherwise defined in the same way as the GP field.
   \item PQ (Integer): Phasing quality, the phred-scaled probability that alleles are ordered incorrectly in a heterozygote (against all other members in the phase set).
   We note that we have not yet included the specific measure for precisely defining ``phasing quality''; our intention for now is simply to reserve the PQ tag for future use as a measure of phasing quality.
   \item PS (non-negative 32-bit Integer): Phase set, defined as a set of phased genotypes to which this genotype belongs.
@@ -2060,6 +2062,8 @@ The characters `{\tt\verb|\|\,,\,"`'\,()\,\verb|{}|}' are now invalid in VCF con
 
 The VCF specification previously disallowed colons (`{\tt :}') in contig names to avoid confusion when parsing breakends, but this was unnecessary.
 Even with contig names containing colons, the breakend mate position notation can be unambiguously parsed because the ``{\tt :}\emph{pos}'' part is \textbf{always} present.
+
+\item Added PP tag which is the phred-scaled analogue to GP
 \end{itemize}
 
 \subsection{Changes between VCFv4.2 and VCFv4.3}

--- a/VCFv4.4.tex
+++ b/VCFv4.4.tex
@@ -425,6 +425,7 @@ See also Section~\ref{sv-format-keys} for a list of genotype keys reserved for s
       HQ		& 2		& Integer	& Haplotype quality \\
       MQ		& 1		& Integer	& RMS mapping quality \\
       PL		& G		& Integer	& Phred-scaled genotype likelihoods rounded to the closest integer \\
+      PP		& G		& Integer	& Phred-scaled genotype posterior probabilities rounded to the closest integer \\
       PQ		& 1		& Integer	& Phasing quality \\
       PS		& 1		& Integer	& Phase set \\
 \end{longtable}
@@ -511,7 +512,8 @@ See also Section~\ref{sv-format-keys} for a list of genotype keys reserved for s
 
   \item HQ (Integer): Haplotype qualities, two comma separated phred qualities.
   \item MQ (Integer): RMS mapping quality, similar to the version in the INFO field.
-  \item PL (Integer): The phred-scaled genotype likelihoods rounded to the closest integer, and otherwise defined precisely as the GL field.
+  \item PL (Integer): The phred-scaled genotype likelihoods rounded to the closest integer, and otherwise defined in the same way as the GL field.
+  \item PP (Integer): The phred-scaled genotype posterior probabilities rounded to the closest integer, and otherwise defined in the same way as the GP field.
   \item PQ (Integer): Phasing quality, the phred-scaled probability that alleles are ordered incorrectly in a heterozygote (against all other members in the phase set).
   We note that we have not yet included the specific measure for precisely defining ``phasing quality''; our intention for now is simply to reserve the PQ tag for future use as a measure of phasing quality.
   \item PS (non-negative 32-bit Integer): Phase set, defined as a set of phased genotypes to which this genotype belongs.
@@ -2065,6 +2067,7 @@ The characters `{\tt\verb|\|\,,\,"`'\,()\,\verb|{}|}' are now invalid in VCF con
 
 The VCF specification previously disallowed colons (`{\tt :}') in contig names to avoid confusion when parsing breakends, but this was unnecessary.
 Even with contig names containing colons, the breakend mate position notation can be unambiguously parsed because the ``{\tt :}\emph{pos}'' part is \textbf{always} present.
+\item Added PP tag which is the phred-scaled analogue to GP
 \end{itemize}
 
 \subsection{Changes between VCFv4.2 and VCFv4.3}


### PR DESCRIPTION
* The PP tag is to GP as PL is to GL
* It seems like we should have added PP when we changed the definition of GP to float.
* Reworded slightly because a local reviewer read the term 'precisely as' as a comment on the precision of representation and not as a description of how the field was defined.

* This came up as part of trying to understand https://github.com/samtools/hts-specs/issues/260.  GATK switched from using GP to PP at that time and it seems like an oversight to not add the tag to the spec.