### PR TITLE
Clarify the existing rules for the `@HD` header

### DIFF
--- a/SAMv1.tex
+++ b/SAMv1.tex
@@ -242,7 +242,7 @@ meanings can be avoided.}
   \endfirsthead
   \cline{1-3}
   \endhead
-  \multicolumn{2}{|l}{\tt @HD} & The header line. The first line if present. \\\cline{2-3}
+  \multicolumn{2}{|l}{\tt @HD} & File-level metadata. Optional. If present, there must be only one {\tt @HD} line and it must be the first line of the file. \\\cline{2-3}
   & {\tt VN}* & Format version. \emph{Accepted format}: {\tt /\char94[0-9]+\char92.[0-9]+\$/}.\\\cline{2-3}
   & {\tt SO} & Sorting order of alignments. \emph{Valid values}: {\tt unknown} (default), {\tt
     unsorted}, {\tt queryname} and {\tt coordinate}. For coordinate sort, the major sort


### PR DESCRIPTION
Clarify the current rules: having an `@HD` line in your SAM headers is optional, but when present it must come first.

I might have just pushed this to **master**, but presenting this as a PR to give @jkbonfield and @yfarjoun a chance to vet the description of `@HD` as _File-level metadata_ (rather than the current meaninglessly-generic _The header line_!).

Okay to merge? I'd hope we can turn this one around in a day :smile: