### PR TITLE
fix htsget OpenAPI repetition

### DIFF
--- a/pub/htsget-openapi.yaml
+++ b/pub/htsget-openapi.yaml
@@ -36,7 +36,7 @@ paths:
         - $ref: '#/components/parameters/endParam'
         - in: query
           name: fields
-          description: A comma separated list of SAM fields to include. By default, i.e., when fields is not specified, all fields will be included
+          description: A comma-separated list of SAM fields to include. By default, i.e., when fields is not specified, all fields will be included
           example: QNAME,RNAME
           required: false
           schema:
@@ -55,18 +55,19 @@ paths:
             type: string
         - in: query
           name: tags
-          description: A comma separated list of tags to include. By default, i.e., when tags is not specified, all tags will be included
+          description: A comma-separated list of tags to include. By default, i.e., when tags is not specified, all tags will be included
           example: MD,NM
           required: false
           schema:
             type: string
         - in: query
           name: notags
-          description: A comma separated list of tags to exclude. By default, i.e., when notags is not specified, no tags will be excluded
+          description: A comma-separated list of tags to exclude. By default, i.e., when notags is not specified, no tags will be excluded
           example: OQ
           required: false
           schema:
             type: string
+
       responses:
         200:
           description: results matching criteria
@@ -100,9 +101,11 @@ paths:
           $ref: '#/components/responses/500InternalServerErrorResponse'
         default:
           $ref: '#/components/responses/500InternalServerErrorResponse'
+
       security:
         - htsget_auth:
           - read:genomic_reads
+
   /variants/{id}:
     get:
       summary: Gets the variants from a pre-indexed id
@@ -125,18 +128,17 @@ paths:
         - $ref: '#/components/parameters/endParam'
         - in: query
           name: tags
-          description: A comma separated list of tags to include, by default all.
-          example: cancer,melanoma
+          description: A comma-separated list of tags to include, by default all.
           required: false
           schema:
             type: string
         - in: query
           name: notags
-          description: A comma separated list of tags to exclude, default none.
-          example: normal,skin
+          description: A comma-separated list of tags to exclude, default none.
           required: false
           schema:
             type: string
+
       responses:
         200:
           description: results matching criteria
@@ -170,9 +172,11 @@ paths:
           $ref: '#/components/responses/500InternalServerErrorResponse'
         default:
           $ref: '#/components/responses/500InternalServerErrorResponse'
+
       security:
         - htsget_auth:
           - read:genomic_variants
+
 components:
   schemas:
     htsgetResponse:
@@ -193,6 +197,7 @@ components:
               type: string
               description: MD5 digest of the blob resulting from concatenating all of the payload data
               example: 8a6049fad4943ff4c6de5c22df97d001
+
     htsgetUrl:
       type: object
       required:
@@ -209,6 +214,7 @@ components:
           description: Indicates whether the header or body of the requested file will be retrieved by this url
           example: body
           enum: [header, body]
+
     htsgetUrlReads:
       allOf:
         - $ref: '#/components/schemas/htsgetUrl'
@@ -218,11 +224,13 @@ components:
               headers:
                 Authorization: Bearer xxxxx
                 Range: bytes=65536-1003750
+
     htsgetUrlVariants:
       allOf:
         - $ref: '#/components/schemas/htsgetUrl'
         - example:
             - url: https://example.com/sample1234/run1.vcf
+
     Error:
       type: object
       description: Generic error response object
@@ -326,6 +334,7 @@ components:
                   example: InternalServerError
                 message:
                   example: An internal server error occurred
+
   parameters:
     idPathParam:
       in: path
@@ -371,6 +380,7 @@ components:
         type: integer
         format: int64
         minimum: 0
+
   securitySchemes:
     htsget_auth:
       type: oauth2
@@ -381,6 +391,7 @@ components:
           scopes:
             read:genomic_reads: read access to genomic reads
             read:genomic_variants: read access to genomic variants
+
   responses:
     400BadRequestResponse:
       description: Bad request

--- a/pub/htsget-openapi.yaml
+++ b/pub/htsget-openapi.yaml
@@ -29,7 +29,7 @@ paths:
         - in: "query"
           name: fields
           description: A list of fields to include, such as QNAME, FLAG, RNAME, etc...
-          example: "fields=QNAME,RNAME"
+          example: "QNAME,RNAME"
           required: false
           schema:
             enum:
@@ -48,14 +48,14 @@ paths:
         - in: "query"
           name: tags
           description: A comma separated list of tags to include, by default all.
-          example: "cancer,melanoma"
+          example: "MD,NM"
           required: false
           schema:
             type: string
         - in: "query"
           name: notags
           description: A comma separated list of tags to exclude, default none.
-          example: "normal,healthy"
+          example: "OQ"
           required: false
           schema:
             type: string

--- a/pub/htsget-openapi.yaml
+++ b/pub/htsget-openapi.yaml
@@ -266,7 +266,7 @@ components:
       allOf:
         - $ref: '#/components/schemas/Error'
         - type: object
-          description: 	Authorization is required to access the resource
+          description: Authorization is required to access the resource
           properties:
             htsget:
               properties:

--- a/pub/htsget-openapi.yaml
+++ b/pub/htsget-openapi.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.2
+openapi: 3.0.3
 servers:
   - description: htsget genomics api
     url: "htsget/1"
@@ -20,51 +20,12 @@ paths:
       description: |
         Searches a pre-indexed object id.
       parameters:
-        - in: "path"
-          name: id
-          description: identifier of the read object
-          required: true
-          schema:
-            type: string
-        - in: "query"
-          name: format
-          description: File format, BAM (default), CRAM.
-          example: "BAM"
-          required: false
-          schema:
-            type: string
-        - in: "query"
-          name: class
-          description: Request different classes of data (such as header or body).
-          example: "header"
-          required: false
-          schema:
-            type: string
-        - in: "query"
-          name: referenceName
-          description: Reference sequence name
-          example: "chr1"
-          required: false
-          schema:
-            type: string
-        - in: "query"
-          name: start
-          description: The start position of the range on the reference, 0-based, inclusive.
-          example: "12312"
-          required: false
-          schema:
-            type: integer
-            format: int64
-            minimum: 0
-        - in: "query"
-          name: end
-          description: The end position of the range on the reference, 0-based exclusive.
-          example: "99999"
-          required: false
-          schema:
-            type: integer
-            format: int64
-            minimum: 0
+        - '$ref': '#/components/parameters/idParam'
+        - '$ref': '#/components/parameters/readsFormatParam'
+        - '$ref': '#/components/parameters/classParam'
+        - '$ref': '#/components/parameters/referenceNameParam'
+        - '$ref': '#/components/parameters/startParam'
+        - '$ref': '#/components/parameters/endParam'
         - in: "query"
           name: fields
           description: A list of fields to include, such as QNAME, FLAG, RNAME, etc...
@@ -98,109 +59,36 @@ paths:
           required: false
           schema:
             type: string
-
-# Cannot reuse those since responses does not accept $ref directly, yet:
-# https://github.com/OAI/OpenAPI-Specification/issues/1586
       responses:
         '200':
-          description: results matching criteria
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/IdResponse'
-              example:
-                {
-                   "htsget" : {
-                      "format" : "BAM",
-                      "urls" : [
-                         {
-                            "url" : "https://htsget.blocksrv.example/sample1234/run1.bam",
-                            "headers" : {
-                               "Authorization" : "Bearer xxxx",
-                               "Range" : "bytes=2744831-9375732"
-                            },
-                            "class" : "body"
-                         }
-                      ]
-                   }
-                }
+          '$ref': '#/components/responses/200OkReadsResponse'
         '400':
-          description: Something went wrong
-          content:
-            application/json:
-              schema:
-                oneOf:
-                  - $ref: '#/components/schemas/UnsupportedFormat'
-                  - $ref: '#/components/schemas/InvalidInput'
-                  - $ref: '#/components/schemas/InvalidRange'
+          '$ref': '#/components/responses/400BadRequestResponse'
         '401':
-          description: Authorization provided is invalid
+          '$ref': '#/components/responses/401UnauthorizedResponse'
         '403':
-          description: Authorization is required to access the resource
+          '$ref': '#/components/responses/403ForbiddenResponse'
         '404':
-          $ref: '#/components/schemas/NotFound'
+          '$ref': '#/components/responses/404NotFoundResponse'
         '500':
-          description: Internal Server Error
+          '$ref': '#/components/responses/500InternalServerErrorResponse'
         default:
-          description: Internal Server Error
-
-
+          '$ref': '#/components/responses/500InternalServerErrorResponse'
       security:
         - htsget_auth:
           - read:genomic_reads
-
-
   /variants/{id}:
     get:
       summary: Gets the variants from a pre-indexed id
       operationId: searchVariantId
       description: Searches a pre-indexed object id.
       parameters:
-        - in: "path"
-          name: id
-          description: identifier of the variant object
-          required: true
-          schema:
-            type: string
-        - in: "query"
-          name: format
-          description: File format, VCF (default), BCF.
-          example: "VCF"
-          required: false
-          schema:
-            type: string
-        - in: "query"
-          name: class
-          description: Request different classes of data (such as header or body).
-          example: "body"
-          required: false
-          schema:
-            type: string
-        - in: "query"
-          name: referenceName
-          description: Reference sequence name
-          example: "chr1"
-          required: false
-          schema:
-            type: string
-        - in: "query"
-          name: start
-          description: The start position of the range on the reference, 0-based, inclusive.
-          example: "12312"
-          required: false
-          schema:
-            type: integer
-            format: int64
-            minimum: 0
-        - in: "query"
-          name: end
-          description: The end position of the range on the reference, 0-based exclusive.
-          example: "99999"
-          required: false
-          schema:
-            type: integer
-            format: int64
-            minimum: 0
+        - '$ref': '#/components/parameters/idParam'
+        - '$ref': '#/components/parameters/variantsFormatParam'
+        - '$ref': '#/components/parameters/classParam'
+        - '$ref': '#/components/parameters/referenceNameParam'
+        - '$ref': '#/components/parameters/startParam'
+        - '$ref': '#/components/parameters/endParam'
         - in: "query"
           name: tags
           description: A comma separated list of tags to include, by default all.
@@ -215,61 +103,30 @@ paths:
           required: false
           schema:
             type: string
-
       responses:
         '200':
-          description: results matching criteria
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/IdResponse'
-              example:
-                {
-                   "htsget" : {
-                      "format" : "VCF",
-                      "urls" : [
-                         {
-                            "url" : "https://htsget.blocksrv.example/sample1234/variants1.vcf",
-                            "headers" : {
-                               "Authorization" : "Bearer xxxx",
-                               "Range" : "bytes=2744831-9375732"
-                            },
-                            "class" : "body"
-                         }
-                      ]
-                   }
-                }
+          '$ref': '#/components/responses/200OkVariantsResponse'
         '400':
-          description: Something went wrong
-          content:
-            application/json:
-              schema:
-                oneOf:
-                  - $ref: '#/components/schemas/UnsupportedFormat'
-                  - $ref: '#/components/schemas/InvalidInput'
-                  - $ref: '#/components/schemas/InvalidRange'
+          '$ref': '#/components/responses/400BadRequestResponse'
         '401':
-          description: Authorization provided is invalid
+          '$ref': '#/components/responses/401UnauthorizedResponse'
         '403':
-          description: Authorization is required to access the resource
+          '$ref': '#/components/responses/403ForbiddenResponse'
         '404':
-          $ref: '#/components/schemas/NotFound'
+          '$ref': '#/components/responses/404NotFoundResponse'
         '500':
-          description: Internal Server Error
+          '$ref': '#/components/responses/500InternalServerErrorResponse'
         default:
-          description: Internal Server Error
-
+          '$ref': '#/components/responses/500InternalServerErrorResponse'
       security:
         - htsget_auth:
           - read:genomic_variants
-
 components:
   schemas:
-    IdResponse:
-      $ref: '#/components/schemas/htsgetResponse'
-
     htsgetResponse:
       type: object
+      required:
+        - htsget
       properties:
         htsget:
           type: object
@@ -279,28 +136,40 @@ components:
           properties:
             format:
               type: string
-              example:
-                "BAM"
             urls:
-              $ref: '#/components/schemas/htsgetUrlsHeaders'
-
+              type: array
+              items:
+                '$ref': '#/components/schemas/htsgetUrl'
             md5:
               type: string
               example: "8a6049fad4943ff4c6de5c22df97d001"
-
-
-    htsgetUrlsHeaders:
-      type: array
-      example:
-        - url: "data:application/vnd.ga4gh.vcf;base64,QkFNAQ=="
-        - url: "https://htsget.blocksrv.example/sample1234/run1.bam"
-          headers:
-            "Authorization": "Bearer xxxxx"
-            "Range": "bytes=65536-1003750"
-      items:
-        $ref: '#/components/schemas/urlsItems'
-
-    urlsItems:
+    htsgetResponseReads:
+      allOf:
+        - '$ref': '#/components/schemas/htsgetResponse'
+        - properties:
+            htsget:
+              properties:
+                format:
+                  example: BAM
+                  enum: [BAM, CRAM]
+                urls:
+                  type: array
+                  items:
+                    '$ref': '#/components/schemas/htsgetUrlReads'
+    htsgetResponseVariants:
+      allOf:
+        - '$ref': '#/components/schemas/htsgetResponse'
+        - properties:
+            htsget:
+              properties:
+                format:
+                  example: VCF
+                  enum: [VCF, BCF]
+                urls:
+                  type: array
+                  items:
+                    '$ref': '#/components/schemas/htsgetUrlVariants'
+    htsgetUrl:
       type: object
       required:
         - url
@@ -309,16 +178,184 @@ components:
           type: string
         headers:
           type: object
-
-    UnsupportedFormat:
-      description: The requested file format is not supported by the server
-    InvalidInput:
-      description: The request parameters do not adhere to the specification
-    InvalidRange:
-      description: The requested range cannot be satisfied
-    NotFound:
-      description: The resource requested was not found
-
+        class:
+          type: string
+          example: body
+          enum: [header, body]
+    htsgetUrlReads:
+      allOf:
+        - '$ref': '#/components/schemas/htsgetUrl'
+        - example:
+            - url: "data:application/vnd.ga4gh.vcf;base64,QkFNAQ=="
+            - url: "https://htsget.blocksrv.example/sample1234/run1.bam"
+              headers:
+                "Authorization": "Bearer xxxxx"
+                "Range": "bytes=65536-1003750"
+    htsgetUrlVariants:
+      allOf:
+        - '$ref': '#/components/schemas/htsgetUrl'
+        - example:
+            - url: https://example.com/sample1234/run1.vcf
+    Error:
+      type: object
+      description: Generic error response object
+      required:
+        - htsget
+      properties:
+        htsget:
+          type: object
+          required:
+            - error
+            - message
+          properties:
+            error:
+              type: string
+              description: The type of error
+              example: NotFound
+            message:
+              type: string
+              description: A message specific to the error providing information on how to debug the problem. Clients MAY display this message to the user.
+              example: The requested resource could not be found
+    InvalidAuthenticationError:
+      allOf:
+        - '$ref': '#/components/schemas/Error'
+        - type: object
+          description: Authorization provided is invalid
+          properties:
+            htsget:
+              properties:
+                error:
+                  example: InvalidAuthentication
+                message:
+                  example: Invalid authentication credentials provided
+    PermissionDeniedError:
+      allOf:
+        - '$ref': '#/components/schemas/Error'
+        - type: object
+          description: 	Authorization is required to access the resource
+          properties:
+            htsget:
+              properties:
+                error:
+                  example: PermissionDenied
+                message:
+                  example: Client is not authorized to access this resource
+    NotFoundError:
+      allOf:
+        - '$ref': '#/components/schemas/Error'
+        - type: object
+          description: The resource requested was not found
+    UnsupportedFormatError:
+      allOf:
+        - '$ref': '#/components/schemas/Error'
+        - type: object
+          description: The requested file format is not supported by the server
+          properties:
+            htsget:
+              properties:
+                error:
+                  example: UnsupportedFormat
+                message:
+                  example: The requested file format is not supported by the server
+    InvalidInputError:
+      allOf:
+        - '$ref': '#/components/schemas/Error'
+        - type: object
+          description: The request parameters do not adhere to the specification
+          properties:
+            htsget:
+              properties:
+                error:
+                  example: InvalidInput
+                message:
+                  example: The request parameters do not adhere to the specification
+    InvalidRangeError:
+      allOf:
+        - '$ref': '#/components/schemas/Error'
+        - type: object
+          description: The requested range cannot be satisfied
+          properties:
+            htsget:
+              properties:
+                error:
+                  example: InvalidRange
+                message:
+                  example: The requested range cannot be satisfied
+    InternalServerError:
+      allOf:
+        - '$ref': '#/components/schemas/Error'
+        - type: object
+          description: Internal server error
+          properties:
+            htsget:
+              properties:
+                error:
+                  example: InternalServerError
+                message:
+                  example: An internal server error occurred
+  parameters:
+    idParam:
+      in: "path"
+      name: id
+      description: read or variant object identifier
+      required: true
+      schema:
+        type: string
+    readsFormatParam:
+      in: "query"
+      name: format
+      description: File format, BAM (default), CRAM.
+      example: BAM
+      required: false
+      schema:
+        type: string
+        enum: [BAM, CRAM]
+    variantsFormatParam:
+      in: "query"
+      name: format
+      description: File format, VCF (default), BCF.
+      example: "VCF"
+      required: false
+      schema:
+        type: string
+        enum: [VCF, BCF]
+    classParam:
+      in: "query"
+      name: class
+      description: Request different classes of data (such as header or body).
+      example: "header"
+      required: false
+      schema:
+        type: string
+        enum: [header, body]
+    referenceNameParam:
+      in: "query"
+      name: referenceName
+      description: Reference sequence name
+      example: "chr1"
+      required: false
+      schema:
+        type: string
+    startParam:
+      in: "query"
+      name: start
+      description: The start position of the range on the reference, 0-based, inclusive.
+      example: "12312"
+      required: false
+      schema:
+        type: integer
+        format: int64
+        minimum: 0
+    endParam:
+      in: "query"
+      name: end
+      description: The end position of the range on the reference, 0-based exclusive.
+      example: "99999"
+      required: false
+      schema:
+        type: integer
+        format: int64
+        minimum: 0
   securitySchemes:
     htsget_auth:
       type: oauth2
@@ -329,3 +366,49 @@ components:
           scopes:
             read:genomic_reads: read access to genomic reads
             read:genomic_variants: read access to genomic variants
+  responses:
+    200OkReadsResponse:
+      description: results matching criteria
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/htsgetResponseReads'
+    200OkVariantsResponse:
+      description: results matching criteria
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/htsgetResponseVariants'
+    400BadRequestResponse:
+      description: Bad request
+      content:
+        application/json:
+          schema:
+            oneOf:
+              - '$ref': '#/components/schemas/UnsupportedFormatError'
+              - '$ref': '#/components/schemas/InvalidInputError'
+              - '$ref': '#/components/schemas/InvalidRangeError'
+    401UnauthorizedResponse:
+      description: Unauthorized
+      content:
+        application/json:
+          schema:
+            '$ref': '#/components/schemas/InvalidAuthenticationError'
+    403ForbiddenResponse:
+      description: Forbidden
+      content:
+        application/json:
+          schema:
+            '$ref': '#/components/schemas/PermissionDeniedError'
+    404NotFoundResponse:
+      description: NotFound
+      content:
+        application/json:
+          schema:
+            '$ref': '#/components/schemas/NotFoundError'
+    500InternalServerErrorResponse:
+      description: Internal Server Error
+      content:
+        application/json:
+          schema:
+            '$ref': '#/components/schemas/InternalServerError'

--- a/pub/htsget-openapi.yaml
+++ b/pub/htsget-openapi.yaml
@@ -1,10 +1,10 @@
 openapi: 3.0.3
 servers:
   - description: htsget genomics api
-    url: "htsget/1"
+    url: htsget/1
 info:
-  description: "This data retrieval API bridges from existing genomics bulk data transfers to a client/server model"
-  version: "1.2.0"
+  description: This data retrieval API bridges from existing genomics bulk data transfers to a client/server model
+  version: 1.2.0
   title: htsget
   contact:
     name: GA4GH
@@ -18,62 +18,88 @@ paths:
       summary: Gets the reads from a pre-indexed id
       operationId: searchReadId
       description: |
-        Searches a pre-indexed object id.
+        Searches a pre-indexed object id
       parameters:
-        - '$ref': '#/components/parameters/idParam'
-        - '$ref': '#/components/parameters/readsFormatParam'
-        - '$ref': '#/components/parameters/classParam'
-        - '$ref': '#/components/parameters/referenceNameParam'
-        - '$ref': '#/components/parameters/startParam'
-        - '$ref': '#/components/parameters/endParam'
-        - in: "query"
+        - $ref: '#/components/parameters/idPathParam'
+        - in: query
+          name: format
+          description: Desired file format
+          example: BAM
+          required: false
+          schema:
+            type: string
+            enum: [BAM, CRAM]
+            default: BAM
+        - $ref: '#/components/parameters/classParam'
+        - $ref: '#/components/parameters/referenceNameParam'
+        - $ref: '#/components/parameters/startParam'
+        - $ref: '#/components/parameters/endParam'
+        - in: query
           name: fields
-          description: A list of fields to include, such as QNAME, FLAG, RNAME, etc...
-          example: "QNAME,RNAME"
+          description: A comma separated list of SAM fields to include. By default, i.e., when fields is not specified, all fields will be included
+          example: QNAME,RNAME
           required: false
           schema:
             enum:
-              - "QNAME"
-              - "FLAG"
-              - "RNAME"
-              - "POS"
-              - "MAPQ"
-              - "CIGAR"
-              - "RNEXT"
-              - "PNEXT"
-              - "TLEN"
-              - "SEQ"
-              - "QUAL"
+              - QNAME
+              - FLAG
+              - RNAME
+              - POS
+              - MAPQ
+              - CIGAR
+              - RNEXT
+              - PNEXT
+              - TLEN
+              - SEQ
+              - QUAL
             type: string
-        - in: "query"
+        - in: query
           name: tags
-          description: A comma separated list of tags to include, by default all.
-          example: "MD,NM"
+          description: A comma separated list of tags to include. By default, i.e., when tags is not specified, all tags will be included
+          example: MD,NM
           required: false
           schema:
             type: string
-        - in: "query"
+        - in: query
           name: notags
-          description: A comma separated list of tags to exclude, default none.
-          example: "OQ"
+          description: A comma separated list of tags to exclude. By default, i.e., when notags is not specified, no tags will be excluded
+          example: OQ
           required: false
           schema:
             type: string
       responses:
-        '200':
-          '$ref': '#/components/responses/200OkReadsResponse'
-        '400':
-          '$ref': '#/components/responses/400BadRequestResponse'
-        '401':
-          '$ref': '#/components/responses/401UnauthorizedResponse'
-        '403':
-          '$ref': '#/components/responses/403ForbiddenResponse'
-        '404':
-          '$ref': '#/components/responses/404NotFoundResponse'
-        '500':
-          '$ref': '#/components/responses/500InternalServerErrorResponse'
+        200:
+          description: results matching criteria
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/htsgetResponse'
+                  - properties:
+                      htsget:
+                        properties:
+                          format:
+                            example: BAM
+                            enum: [BAM, CRAM]
+                          urls:
+                            type: array
+                            description: An array providing URLs from which raw alignment data can be retrieved
+                            items:
+                              $ref: '#/components/schemas/htsgetUrlReads'
+                        required:
+                          - urls
+        400:
+          $ref: '#/components/responses/400BadRequestResponse'
+        401:
+          $ref: '#/components/responses/401UnauthorizedResponse'
+        403:
+          $ref: '#/components/responses/403ForbiddenResponse'
+        404:
+          $ref: '#/components/responses/404NotFoundResponse'
+        500:
+          $ref: '#/components/responses/500InternalServerErrorResponse'
         default:
-          '$ref': '#/components/responses/500InternalServerErrorResponse'
+          $ref: '#/components/responses/500InternalServerErrorResponse'
       security:
         - htsget_auth:
           - read:genomic_reads
@@ -81,43 +107,69 @@ paths:
     get:
       summary: Gets the variants from a pre-indexed id
       operationId: searchVariantId
-      description: Searches a pre-indexed object id.
+      description: Searches a pre-indexed object id
       parameters:
-        - '$ref': '#/components/parameters/idParam'
-        - '$ref': '#/components/parameters/variantsFormatParam'
-        - '$ref': '#/components/parameters/classParam'
-        - '$ref': '#/components/parameters/referenceNameParam'
-        - '$ref': '#/components/parameters/startParam'
-        - '$ref': '#/components/parameters/endParam'
-        - in: "query"
-          name: tags
-          description: A comma separated list of tags to include, by default all.
-          example: "cancer,melanoma"
+        - $ref: '#/components/parameters/idPathParam'
+        - in: query
+          name: format
+          description: Desired file format
+          example: VCF
           required: false
           schema:
             type: string
-        - in: "query"
+            enum: [VCF, BCF]
+            default: VCF
+        - $ref: '#/components/parameters/classParam'
+        - $ref: '#/components/parameters/referenceNameParam'
+        - $ref: '#/components/parameters/startParam'
+        - $ref: '#/components/parameters/endParam'
+        - in: query
+          name: tags
+          description: A comma separated list of tags to include, by default all.
+          example: cancer,melanoma
+          required: false
+          schema:
+            type: string
+        - in: query
           name: notags
           description: A comma separated list of tags to exclude, default none.
-          example: "normal,skin"
+          example: normal,skin
           required: false
           schema:
             type: string
       responses:
-        '200':
-          '$ref': '#/components/responses/200OkVariantsResponse'
-        '400':
-          '$ref': '#/components/responses/400BadRequestResponse'
-        '401':
-          '$ref': '#/components/responses/401UnauthorizedResponse'
-        '403':
-          '$ref': '#/components/responses/403ForbiddenResponse'
-        '404':
-          '$ref': '#/components/responses/404NotFoundResponse'
-        '500':
-          '$ref': '#/components/responses/500InternalServerErrorResponse'
+        200:
+          description: results matching criteria
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/htsgetResponse'
+                  - properties:
+                      htsget:
+                        properties:
+                          format:
+                            example: VCF
+                            enum: [VCF, BCF]
+                          urls:
+                            type: array
+                            description: An array providing URLs from which raw variant data can be retrieved
+                            items:
+                              $ref: '#/components/schemas/htsgetUrlVariants'
+                        required:
+                          - urls
+        400:
+          $ref: '#/components/responses/400BadRequestResponse'
+        401:
+          $ref: '#/components/responses/401UnauthorizedResponse'
+        403:
+          $ref: '#/components/responses/403ForbiddenResponse'
+        404:
+          $ref: '#/components/responses/404NotFoundResponse'
+        500:
+          $ref: '#/components/responses/500InternalServerErrorResponse'
         default:
-          '$ref': '#/components/responses/500InternalServerErrorResponse'
+          $ref: '#/components/responses/500InternalServerErrorResponse'
       security:
         - htsget_auth:
           - read:genomic_variants
@@ -130,45 +182,17 @@ components:
       properties:
         htsget:
           type: object
+          description: Container for response object
           required:
             - format
-            - urls
           properties:
             format:
               type: string
-            urls:
-              type: array
-              items:
-                '$ref': '#/components/schemas/htsgetUrl'
+              description: Response data is in this format
             md5:
               type: string
-              example: "8a6049fad4943ff4c6de5c22df97d001"
-    htsgetResponseReads:
-      allOf:
-        - '$ref': '#/components/schemas/htsgetResponse'
-        - properties:
-            htsget:
-              properties:
-                format:
-                  example: BAM
-                  enum: [BAM, CRAM]
-                urls:
-                  type: array
-                  items:
-                    '$ref': '#/components/schemas/htsgetUrlReads'
-    htsgetResponseVariants:
-      allOf:
-        - '$ref': '#/components/schemas/htsgetResponse'
-        - properties:
-            htsget:
-              properties:
-                format:
-                  example: VCF
-                  enum: [VCF, BCF]
-                urls:
-                  type: array
-                  items:
-                    '$ref': '#/components/schemas/htsgetUrlVariants'
+              description: MD5 digest of the blob resulting from concatenating all of the payload data
+              example: 8a6049fad4943ff4c6de5c22df97d001
     htsgetUrl:
       type: object
       required:
@@ -176,24 +200,27 @@ components:
       properties:
         url:
           type: string
+          description: URL to download data block
         headers:
           type: object
+          description: JSON object of key-value pairs representing HTTP headers. If supplied, the client MUST provide these as headers to the data download url
         class:
           type: string
+          description: Indicates whether the header or body of the requested file will be retrieved by this url
           example: body
           enum: [header, body]
     htsgetUrlReads:
       allOf:
-        - '$ref': '#/components/schemas/htsgetUrl'
+        - $ref: '#/components/schemas/htsgetUrl'
         - example:
-            - url: "data:application/vnd.ga4gh.vcf;base64,QkFNAQ=="
-            - url: "https://htsget.blocksrv.example/sample1234/run1.bam"
+            - url: data:application/vnd.ga4gh.vcf;base64,QkFNAQ==
+            - url: https://htsget.blocksrv.example/sample1234/run1.bam
               headers:
-                "Authorization": "Bearer xxxxx"
-                "Range": "bytes=65536-1003750"
+                Authorization: Bearer xxxxx
+                Range: bytes=65536-1003750
     htsgetUrlVariants:
       allOf:
-        - '$ref': '#/components/schemas/htsgetUrl'
+        - $ref: '#/components/schemas/htsgetUrl'
         - example:
             - url: https://example.com/sample1234/run1.vcf
     Error:
@@ -204,6 +231,7 @@ components:
       properties:
         htsget:
           type: object
+          description: Container for the error response object
           required:
             - error
             - message
@@ -211,14 +239,12 @@ components:
             error:
               type: string
               description: The type of error
-              example: NotFound
             message:
               type: string
               description: A message specific to the error providing information on how to debug the problem. Clients MAY display this message to the user.
-              example: The requested resource could not be found
     InvalidAuthenticationError:
       allOf:
-        - '$ref': '#/components/schemas/Error'
+        - $ref: '#/components/schemas/Error'
         - type: object
           description: Authorization provided is invalid
           properties:
@@ -230,7 +256,7 @@ components:
                   example: Invalid authentication credentials provided
     PermissionDeniedError:
       allOf:
-        - '$ref': '#/components/schemas/Error'
+        - $ref: '#/components/schemas/Error'
         - type: object
           description: 	Authorization is required to access the resource
           properties:
@@ -242,12 +268,19 @@ components:
                   example: Client is not authorized to access this resource
     NotFoundError:
       allOf:
-        - '$ref': '#/components/schemas/Error'
+        - $ref: '#/components/schemas/Error'
         - type: object
           description: The resource requested was not found
+          properties:
+            htsget:
+                properties:
+                    error:
+                        example: NotFound
+                    message:
+                        example: The requested resource could not be found
     UnsupportedFormatError:
       allOf:
-        - '$ref': '#/components/schemas/Error'
+        - $ref: '#/components/schemas/Error'
         - type: object
           description: The requested file format is not supported by the server
           properties:
@@ -259,7 +292,7 @@ components:
                   example: The requested file format is not supported by the server
     InvalidInputError:
       allOf:
-        - '$ref': '#/components/schemas/Error'
+        - $ref: '#/components/schemas/Error'
         - type: object
           description: The request parameters do not adhere to the specification
           properties:
@@ -271,7 +304,7 @@ components:
                   example: The request parameters do not adhere to the specification
     InvalidRangeError:
       allOf:
-        - '$ref': '#/components/schemas/Error'
+        - $ref: '#/components/schemas/Error'
         - type: object
           description: The requested range cannot be satisfied
           properties:
@@ -283,7 +316,7 @@ components:
                   example: The requested range cannot be satisfied
     InternalServerError:
       allOf:
-        - '$ref': '#/components/schemas/Error'
+        - $ref: '#/components/schemas/Error'
         - type: object
           description: Internal server error
           properties:
@@ -294,63 +327,45 @@ components:
                 message:
                   example: An internal server error occurred
   parameters:
-    idParam:
-      in: "path"
+    idPathParam:
+      in: path
       name: id
       description: read or variant object identifier
       required: true
       schema:
         type: string
-    readsFormatParam:
-      in: "query"
-      name: format
-      description: File format, BAM (default), CRAM.
-      example: BAM
-      required: false
-      schema:
-        type: string
-        enum: [BAM, CRAM]
-    variantsFormatParam:
-      in: "query"
-      name: format
-      description: File format, VCF (default), BCF.
-      example: "VCF"
-      required: false
-      schema:
-        type: string
-        enum: [VCF, BCF]
     classParam:
-      in: "query"
+      in: query
       name: class
-      description: Request different classes of data (such as header or body).
-      example: "header"
+      description: Request different classes of data. By default, i.e., when class is not specified, the response will represent a complete read or variant data stream, encompassing SAM/CRAM/VCF headers, body data records, and EOF marker
+      example: header
       required: false
       schema:
         type: string
-        enum: [header, body]
+        enum: [header]
     referenceNameParam:
-      in: "query"
+      in: query
       name: referenceName
       description: Reference sequence name
-      example: "chr1"
+      example: chr1
       required: false
       schema:
         type: string
     startParam:
-      in: "query"
+      in: query
       name: start
-      description: The start position of the range on the reference, 0-based, inclusive.
-      example: "12312"
+      description: The start position of the range on the reference, 0-based, inclusive
+      example: 12312
       required: false
       schema:
         type: integer
         format: int64
         minimum: 0
     endParam:
-      in: "query"
+      in: query
       name: end
-      description: The end position of the range on the reference, 0-based exclusive.
-      example: "99999"
+      description: The end position of the range on the reference, 0-based exclusive
+      example: 99999
       required: false
       schema:
         type: integer
@@ -367,48 +382,36 @@ components:
             read:genomic_reads: read access to genomic reads
             read:genomic_variants: read access to genomic variants
   responses:
-    200OkReadsResponse:
-      description: results matching criteria
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/htsgetResponseReads'
-    200OkVariantsResponse:
-      description: results matching criteria
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/htsgetResponseVariants'
     400BadRequestResponse:
       description: Bad request
       content:
         application/json:
           schema:
             oneOf:
-              - '$ref': '#/components/schemas/UnsupportedFormatError'
-              - '$ref': '#/components/schemas/InvalidInputError'
-              - '$ref': '#/components/schemas/InvalidRangeError'
+              - $ref: '#/components/schemas/UnsupportedFormatError'
+              - $ref: '#/components/schemas/InvalidInputError'
+              - $ref: '#/components/schemas/InvalidRangeError'
     401UnauthorizedResponse:
       description: Unauthorized
       content:
         application/json:
           schema:
-            '$ref': '#/components/schemas/InvalidAuthenticationError'
+            $ref: '#/components/schemas/InvalidAuthenticationError'
     403ForbiddenResponse:
       description: Forbidden
       content:
         application/json:
           schema:
-            '$ref': '#/components/schemas/PermissionDeniedError'
+            $ref: '#/components/schemas/PermissionDeniedError'
     404NotFoundResponse:
       description: NotFound
       content:
         application/json:
           schema:
-            '$ref': '#/components/schemas/NotFoundError'
+            $ref: '#/components/schemas/NotFoundError'
     500InternalServerErrorResponse:
       description: Internal Server Error
       content:
         application/json:
           schema:
-            '$ref': '#/components/schemas/InternalServerError'
+            $ref: '#/components/schemas/InternalServerError'


### PR DESCRIPTION
@mlin @jmarshall @brainstorm @daviesrob 

Partial solution to fixing OpenAPI repetition. ( issue #489 )

1. Responses
Added a generic `Error` Schema, and an Error schema for each error code outlined in the htsget specification text. These error 'subclasses' inherit from the base `Error` schema through the `allOf` property. These errors are then grouped in `#/components/responses` according to their error code, which are referenced in each API route.

Important to Note: The master branch OpenAPI spec currently has a **misalignment** with the spec markdown, as the OpenAPI error code responses do not prescribe a JSON response with `error` and `message` properties nested under `htsget`. This PR aims to correct this by defining the Error object.

2. Parameters
`class`, `referenceName`, `start`, `end` were moved to `#/components/parameters` and referenced by each endpoint. The description for `id` was made generic and also moved to components. `format` is kept as 2 distinct parameters, as they have different enum constraints for reads or variants.

I was unsure what to do with `fields`, `tags`, and `notags`. What do `tags` refer to in a reads context, and in a variants context? In a BAM/CRAM context, I thought they referred to the two-letter SAMtags the client wanted (ie. column 12 and after), but the examples do not reflect this. Would appreciate clarification on this.

3. Schemas
I attempted to model inheritance and polymorphism of certain schemas by relegating common properties to a parent schema, and having child schemas 'inherit' parent properties via the `allOf` property. This is seen in the parent `htsgetResponse`, and its children, `htsgetResponseReads` and `htsgetResponseVariants`. Polymorphism was needed because the allowed `format` values are different for reads and variants.
Similarly, there is `htsgetUrl`, `htsgetUrlReads` and `htsgetUrlVariants`. The child schemas contain different example values, which is important for the example objects in Swagger UI.
