### PR TITLE
Fix the description of BAI metadata pseudo-bin file offsets

### DIFF
--- a/CSIv1.tex
+++ b/CSIv1.tex
@@ -36,6 +36,14 @@
 \end{tabular}}
 \end{table}
 
+\noindent
+The following functions generalise those given in the SAM specification for a BAI-style binning scheme.
+Note that in CSI \textit{depth} refers to the scheme's maximal depth, i.e., the level number of the scheme's smallest bins, and the single-bin level spanning the entire coordinate range is level 0.
+Hence the BAI-style binning scheme, with six levels in total, is represented by $\mbox{\sf min\_shift} = 14, \mbox{\sf depth} = 5$.
+
+CSI index files may contain metadata pseudo-bins for each reference sequence, with the same contents as BAI pseudo-bins.
+In CSI, the pseudo-bins have bin number $\mbox{\sf bin\_limit}(\mbox{\sf min\_shift}, \mbox{\sf depth}) + 1$.
+
 {\footnotesize
 \begin{verbatim}
 /* calculate bin given an alignment covering [beg,end) (zero-based, half-close-half-open) */
@@ -46,6 +54,7 @@ int reg2bin(int64_t beg, int64_t end, int min_shift, int depth)
         if (beg>>s == end>>s) return t + (beg>>s);
     return 0;
 }
+
 /* calculate the list of bins that may overlap with region [beg,end) (zero-based) */
 int reg2bins(int64_t beg, int64_t end, int min_shift, int depth, int *bins)
 {
@@ -55,6 +64,12 @@ int reg2bins(int64_t beg, int64_t end, int min_shift, int depth, int *bins)
         for (i = b; i <= e; ++i) bins[n++] = i;
     }
     return n;
+}
+
+/* calculate maximum bin number -- valid bin numbers range within [0,bin_limit) */
+int bin_limit(int min_shift, int depth)
+{
+    return ((1 << (depth+1)*3) - 1) / 7;
 }
 \end{verbatim}
 }

--- a/SAMv1.tex
+++ b/SAMv1.tex
@@ -1307,7 +1307,7 @@ saved.
 \footnotetext{The number of chunks in a single bin is effectively limited by available memory and in any case is typically a maximum of some thousands.}
 
 The index file may optionally contain additional metadata providing a summary
-of the number of mapped and unmapped read-segments per reference sequence,
+of the number of mapped and placed unmapped read-segments per reference sequence,
 and of any unplaced unmapped read-segments.\footnote{By \emph{placed unmapped
 read} we mean a read that is unmapped according to its {\sf FLAG} but whose
 {\sf RNAME} and~{\sf POS} fields are filled in, thus ``placing'' it on a
@@ -1328,12 +1328,16 @@ compatible with real bins and their chunks:
   \hline
   {\sf bin} & Magic bin number & {\tt uint32\_t} & 37450 \\\hline
   {\sf n\_chunk} & \# chunks & {\tt uint32\_t} & 2 \\\hline
-  {\sf unmapped\_beg} & (Virtual) file offset of the start of placed unmapped reads & {\tt uint64\_t} & \\\hline
-  {\sf unmapped\_end} & (Virtual) file offset of the end of placed unmapped reads & {\tt uint64\_t} & \\\hline
+  {\sf ref\_beg} & (Virtual) file offset of the start of reads placed on this reference& {\tt uint64\_t} & \\\hline
+  {\sf ref\_end} & (Virtual) file offset of the end of reads placed on this reference& {\tt uint64\_t} & \\\hline
   {\sf n\_mapped} & Number of mapped read-segments for this reference & {\tt uint64\_t} & \\\hline
   {\sf n\_unmapped} & Number of unmapped read-segments for this reference & {\tt uint64\_t} & \\\hline
 \end{tabular}
 \end{table}
+
+\noindent
+The {\sf ref\_beg}/{\sf ref\_end} fields locate the first and last reads on this reference sequence, whether they are mapped or placed unmapped.
+Thus they are equal to the minimum {\sf chunk\_beg} and maximum {\sf chunk\_end} respectively.
 
 \subsection{C source code for computing bin number and overlapping bins}\label{sec:code}
 The following functions compute bin numbers and overlaps for a BAI-style
@@ -1425,6 +1429,7 @@ at \url{https://github.com/samtools/hts-specs}.}
 \subsection*{1.6: 28 November 2017 to current}
 
 \begin{itemize}
+\item Correct the description of index pseudo-bins, which previously stated that {\sf ref\_beg}/{\sf ref\_end}, then named {\sf unmapped\_beg}/{\sf unmapped\_end}, include only placed unmapped reads. (Jul 2020)
 \item Add {\tt DNBSEQ} to the list of {\tt @RG PL} header tag values. (Apr 2020)
 \item Add {\tt @SQ TP} circular/linear topology header tag. (May 2019)
 \item\textbf{Restricted the allowable punctuation characters in reference sequence names} (in {\tt @SQ SN}, {\sf RNAME}, etc).


### PR DESCRIPTION
Ever since the metadata pseudo-bins were added to the spec in #2, their virtual file offset entries have been misdescribed as locating the **placed unmapped reads** (which are not contiguous but spread throughout the reads on the chromosome), contrary to how they are computed by both HTSlib and HTSJDK and to Heng Li's original [description on the samtools-devel mailing list](https://sourceforge.net/p/samtools/mailman/message/25690499/):

> […] each chr has a bin 37450 which currently has two records […]
> The first record keeps the start and end file offset of the entire chr (chunk_beg[0]=chr_start_off, chunk_end[0]=chr_end_off).

Fixes #498 — see additional background there.

Also mention in _CSIv1.tex_ that metadata pseudo-bins appear in CSI too, with the same contents as BAI, and generalise their bin number calculation from BAI's 37450. Clarify CSI “depth”, which is more _max_level_ than _number-of-levels_.