### PR TITLE
Correct CRAM MF bit 2: it means unmapped, not mapped.

### DIFF
--- a/CRAMv2.1.tex
+++ b/CRAMv2.1.tex
@@ -964,7 +964,7 @@ The following flags are defined for each CRAM read record:
 0x10 &  & SEQ being reverse complemented\tabularnewline
 \hline
 0x20 & calculated* or stored in the mate's info & SEQ of the next segment in the 
-template being reversed\tabularnewline
+template being reverse complemented\tabularnewline
 \hline
 0x40 &  & the first segment in the template\tabularnewline
 \hline
@@ -1128,7 +1128,7 @@ following bit flags are defined:
 0x1 & mate negative strand bit & the bit is set if the mate is on the negative 
 strand\tabularnewline
 \hline
-0x2 & mate mapped bit & the bit is set if the mate is mapped\tabularnewline
+0x2 & mate unmapped bit & the bit is set if the mate is unmapped\tabularnewline
 \hline
 \end{tabular}
 

--- a/CRAMv3.tex
+++ b/CRAMv3.tex
@@ -1186,7 +1186,7 @@ Note however some of these flags can be derived during decode, so may be omitted
 0x10 &  & SEQ being reverse complemented\tabularnewline
 \hline
 0x20 & calculated\tnote{b}\ \ or stored in the mate's info & SEQ of the next segment in the
-template being reversed\tabularnewline
+template being reverse complemented\tabularnewline
 \hline
 0x40 &  & the first segment in the template\tnote{c}\tabularnewline
 \hline
@@ -1388,7 +1388,7 @@ The following bit flags are defined:
 0x1 & mate negative strand bit & the bit is set if the mate is on the negative
 strand\tabularnewline
 \hline
-0x2 & mate mapped bit & the bit is set if the mate is mapped\tabularnewline
+0x2 & mate unmapped bit & the bit is set if the mate is unmapped\tabularnewline
 \hline
 \end{tabular}
 


### PR DESCRIPTION
The pseudocode in CRAMv3.tex was already correct.

This flaw appears to date all the way back to the initial CRAM1.0 pdf document:

https://www.ebi.ac.uk/sites/ebi.ac.uk/files/groups/ena/documents/cram_format_1.0.1.pdf

Implementation-wise, the initial commit for the CRAMtools Java implementation of CRAM (enasequence/cramtools@6576802) had (Oct 28 2012):

```
        public byte getMateFlags() {
                if (mateFlags == null) {
                        byte b = 0;
                        b |= mateMapped ? 1 : 0;
                        b <<= 1;
                        b |= mateNegativeStrand ? 1 : 0;
                        mateFlags = new Byte(b);
                }
                return mateFlags;
        }
```

7 days later, commit enasequence/cramtools@f0cf055 changed that with:

```
        public byte getMateFlags() {
                if (mateFlags == null) {
                        byte b = 0;
-                       b |= mateMapped ? 1 : 0;
+                       b |= mateUmapped ? 1 : 0;
                        b <<= 1;
                        b |= mateNegativeStrand ? 1 : 0;
                        mateFlags = new Byte(b);
```

This is shortly before the first release of CRAM (indeed the commit message for above is "cram2bam, almost there").  It appears the spec was never updated so has been wrong since day 1.