### PR TITLE
Jerome Kelleher is no longer an htsget maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -30,9 +30,10 @@ Past VCF/BCF maintainers include Cristina Yenyxe Gonzalez Garcia, Ryan Poplin, a
 
 ### Htsget
 
-* Jerome Kelleher (@jeromekelleher)
 * Mike Lin (@mlin)
 * John Marshall (@jmarshall)
+
+Past htsget maintainers include Jerome Kelleher.
 
 ### Refget
 


### PR DESCRIPTION
Jerome is no longer an htsget specification maintainer, as discussed during previous htsget meetings.