### PR TITLE
Add LEN INFO field as a replacement for END

### DIFF
--- a/VCFv4.4.draft.tex
+++ b/VCFv4.4.draft.tex
@@ -373,9 +373,10 @@ Fixed fields are:
 	CIGAR		& A		& String	& Cigar string describing how to align an alternate allele to the reference allele \\
 	DB		& 0		& Flag		& dbSNP membership \\
 	DP		& 1		& Integer	& Combined depth across samples \\
-	END		& 1		& Integer	& End position on CHROM (used with symbolic alleles; see below) \\
+	END		& 1		& Integer	& End position on CHROM (deprecated; prefer LEN; see below) \\
 	H2		& 0		& Flag		& HapMap2 membership \\
 	H3		& 0		& Flag		& HapMap3 membership \\
+	LEN		& 1		& Integer 		& Length of variant (used with symbolic alleles; see below) \\
 	MQ		& 1		& Float		& RMS mapping quality \\
 	MQ0   		& 1		& Integer	& Number of MAPQ == 0 reads \\
 	NS		& 1		& Integer	& Number of samples with data \\
@@ -387,11 +388,19 @@ Fixed fields are:
 
 \begin{itemize}
 \renewcommand{\labelitemii}{$\circ$}
-\item END: End reference position (1-based), indicating the variant spans positions POS--END on reference/contig CHROM.
-Normally this is the position of the last base in the REF allele, so it can be derived from POS and the length of REF, and no END INFO field is needed.
-However when symbolic alleles are used, e.g.\ in gVCF or structural variants, an explicit END INFO field provides variant span information that is otherwise unknown.
+\item LEN / END: Fields used to explicitly specify the end position of the variant on the reference/contig CHROM.
+Normally this is the position of the last base in the REF allele, so it can be derived from POS and the length of REF, and no additional INFO field is needed.
+However when symbolic alleles are used, e.g.\ in gVCF or structural variants, an additional explicit field provides variant span information that is otherwise unknown.
+These fields are used to compute BCF's {\tt rlen} field (see~\ref{BcfSiteEncoding}) and are important when indexing VCF/BCF files to enable random access and querying by position.
 
-This field is used to compute BCF's {\tt rlen} field (see~\ref{BcfSiteEncoding}) and is important when indexing VCF/BCF files to enable random access and querying by position.
+  \begin{itemize}
+   \item END: End reference position (1-based), indicating the variant spans positions POS--END on reference/contig CHROM.
+   END is deprecated and has been replaced with LEN.
+   \item LEN: The length of the variant's alignment to the reference indicating the variant spans positions POS--(LEN - 1) on reference/contig CHROM.
+  \end{itemize}
+
+At most one of LEN or END should be present on each variant line.
+If both are present they must be consistent with each other.
 \end{itemize}
 
 \subsubsection{Genotype fields}
@@ -569,10 +578,10 @@ When a key reflects a property of a single alt allele (e.g.\ SVLEN), then when t
 \begin{verbatim}
 ##INFO=<ID=IMPRECISE,Number=0,Type=Flag,Description="Imprecise structural variation">
 ##INFO=<ID=NOVEL,Number=0,Type=Flag,Description="Indicates a novel structural variation">
-##INFO=<ID=END,Number=1,Type=Integer,Description="End position of the variant described in this record">
+##INFO=<ID=LEN,Number=1,Type=Integer,Description="Length of the variant described in this record">
 \end{verbatim}
 \normalsize
-For precise variants, END is $\mbox{POS} + \mbox{length of REF allele} - 1$, and the for imprecise variants the corresponding best estimate.
+For precise variants, LEN is \mbox{length of REF allele}, and the for imprecise variants the corresponding best estimate.
 
 \footnotesize
 \begin{verbatim}
@@ -852,7 +861,7 @@ VCF STRUCTURAL VARIANT EXAMPLE
 ##INFO=<ID=BKPTID,Number=.,Type=String,Description="ID of the assembled alternate allele in the assembly file">
 ##INFO=<ID=CIEND,Number=2,Type=Integer,Description="Confidence interval around END for imprecise variants">
 ##INFO=<ID=CIPOS,Number=2,Type=Integer,Description="Confidence interval around POS for imprecise variants">
-##INFO=<ID=END,Number=1,Type=Integer,Description="End position of the variant described in this record">
+##INFO=<ID=LEN,Number=1,Type=Integer,Description="Length of the variant described in this record">
 ##INFO=<ID=HOMLEN,Number=.,Type=Integer,Description="Length of base pair identical micro-homology at event breakpoints">
 ##INFO=<ID=HOMSEQ,Number=.,Type=String,Description="Sequence of base pair identical micro-homology at event breakpoints">
 ##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Difference in length between REF and ALT alleles">
@@ -872,12 +881,12 @@ VCF STRUCTURAL VARIANT EXAMPLE
 ##FORMAT=<ID=CN,Number=1,Type=Integer,Description="Copy number genotype for imprecise events">
 ##FORMAT=<ID=CNQ,Number=1,Type=Float,Description="Copy number genotype quality for imprecise events">
 #CHROM POS     ID        REF              ALT          QUAL FILTER INFO                                                               FORMAT       NA00001
-1      2827694 rs2376870 CGTGGATGCGGGGAC  C            .    PASS   SVTYPE=DEL;END=2827708;HOMLEN=1;HOMSEQ=G;SVLEN=-14                 GT:GQ        1/1:14
-2       321682 .         T                <DEL>        6    PASS   SVTYPE=DEL;END=321887;SVLEN=-205;CIPOS=-56,20;CIEND=-10,62         GT:GQ        0/1:12
-2     14477084 .         C                <DEL:ME:ALU> 12   PASS   SVTYPE=DEL;END=14477381;SVLEN=-297;CIPOS=-22,18;CIEND=-12,32       GT:GQ        0/1:12
-3      9425916 .         C                <INS:ME:L1>  23   PASS   SVTYPE=INS;END=9425916;SVLEN=6027;CIPOS=-16,22                     GT:GQ        1/1:15
-3     12665100 .         A                <DUP>        14   PASS   SVTYPE=DUP;END=12686200;SVLEN=21100;CIPOS=-500,500;CIEND=-500,500  GT:GQ:CN:CNQ ./.:0:3:16.2
-4     18665128 .         T                <DUP:TANDEM> 11   PASS   SVTYPE=DUP;END=18665204;SVLEN=76;CIPOS=-10,10;CIEND=-10,10         GT:GQ:CN:CNQ ./.:0:5:8.3
+1      2827694 rs2376870 CGTGGATGCGGGGAC  C            .    PASS   SVTYPE=DEL;LEN=15;2827708;HOMLEN=1;HOMSEQ=G;SVLEN=-14                 GT:GQ        1/1:14
+2       321682 .         T                <DEL>        6    PASS   SVTYPE=DEL;LEN=206;SVLEN=-205;CIPOS=-56,20;CIEND=-10,62         GT:GQ        0/1:12
+2     14477084 .         C                <DEL:ME:ALU> 12   PASS   SVTYPE=DEL;LEN=298;SVLEN=-297;CIPOS=-22,18;CIEND=-12,32       GT:GQ        0/1:12
+3      9425916 .         C                <INS:ME:L1>  23   PASS   SVTYPE=INS;LEN=1;SVLEN=6027;CIPOS=-16,22                     GT:GQ        1/1:15
+3     12665100 .         A                <DUP>        14   PASS   SVTYPE=DUP;LEN=21101;SVLEN=21100;CIPOS=-500,500;CIEND=-500,500  GT:GQ:CN:CNQ ./.:0:3:16.2
+4     18665128 .         T                <DUP:TANDEM> 11   PASS   SVTYPE=DUP;LEN=77;SVLEN=76;CIPOS=-10,10;CIEND=-10,10         GT:GQ:CN:CNQ ./.:0:5:8.3
 \end{verbatim}
 \end{landscape}
 \pagebreak
@@ -1119,7 +1128,7 @@ Either one uses the short hand notation described previously (recommended for si
 \small
 \begin{tabular}{ l l l l l l l l }
 \#CHROM & POS & ID & REF & ALT & QUAL & FILTER & INFO \\
-2 & 321682 & INV0 & T & $<$INV$>$ & 6 & PASS & SVTYPE=INV;END=421681 \\
+2 & 321682 & INV0 & T & $<$INV$>$ & 6 & PASS & SVTYPE=INV;LEN=100000 \\
 \end{tabular}
 \normalsize
 \vspace{0.3cm}
@@ -1202,7 +1211,7 @@ Another possible reason for calling single breakends is an observed but unexplai
 \begin{tabular}{ l l l l l l l l }
 \#CHROM & POS & ID & REF & ALT & QUAL & FILTER & INFO \\
 3 & 12665 & bnd\_X & A & .A & 6 & PASS & SVTYPE=BND;CIPOS=-50,50 \\
-3 & 12665 & . & A & $<$DUP$>$ & 14 & PASS & SVTYPE=DUP;END=13686;CIPOS=-50,50;CIEND=-50,50 \\
+3 & 12665 & . & A & $<$DUP$>$ & 14 & PASS & SVTYPE=DUP;LEN=1022;CIPOS=-50,50;CIEND=-50,50 \\
 3 & 13686 & bnd\_Y & T & T. & 6 & PASS & SVTYPE=BND;CIPOS=-50,50 \\
 \end{tabular}
 \normalsize
@@ -1215,7 +1224,7 @@ Finally, if an insertion is detected but only the first few base-pairs provided 
 \begin{tabular}{ l l l l l l l l }
 \#CHROM & POS & ID & REF & ALT & QUAL & FILTER & INFO \\
 3 & 12665 & bnd\_X & A & .TGCA & 6 & PASS & SVTYPE=BND;CIPOS=-50,50 \\
-3 & 12665 & . & A & $<$DUP$>$ & 14 & PASS & SVTYPE=DUP;END=13686;CIPOS=-50,50;CIEND=-50,50 \\
+3 & 12665 & . & A & $<$DUP$>$ & 14 & PASS & SVTYPE=DUP;LEN=1022;CIPOS=-50,50;CIEND=-50,50 \\
 3 & 13686 & bnd\_Y & T & TCC. & 6 & PASS & SVTYPE=BND;CIPOS=-50,50 \\
 \end{tabular}
 \normalsize
@@ -1387,7 +1396,7 @@ Haplotype quality & 30 & 40 & 40 \\
 
 \pagebreak
 \subsection{Representing unspecified alleles and REF-only blocks (gVCF)}
-In order to report sequencing data evidence for both variant and non-variant positions in the genome, the VCF specification allows to represent blocks of reference-only calls in a single record using the END INFO tag, an idea originally introduced by the gVCF file format\footnote{\url{https://help.basespace.illumina.com/articles/descriptive/gvcf-files/}}.
+In order to report sequencing data evidence for both variant and non-variant positions in the genome, the VCF specification allows to represent blocks of reference-only calls in a single record using the LEN INFO tag, an idea originally introduced by the gVCF file format\footnote{\url{https://help.basespace.illumina.com/articles/descriptive/gvcf-files/}}.
 
 The convention adopted here is to represent reference evidence as likelihoods against an unknown alternate allele represented as $<$*$>$.
 Think of this as the likelihood for reference as compared to any other possible alternate allele (both SNP, indel, or otherwise).
@@ -1398,13 +1407,13 @@ Example records are given below:
 \begin{flushleft}
 \begin{tabular}{ l l l l l l l l l l }
 \#CHROM & POS & ID & REF & ALT & QUAL & FILTER & INFO & FORMAT & Sample \\
-1 & 4370 & . & G & $<$*$>$ & . & . & END=4383 & GT:DP:GQ:MIN\_DP:PL & 0/0:25:60:23:0,60,900 \\
-1 & 4384 & . & C & $<$*$>$ & . & . & END=4388 & GT:DP:GQ:MIN\_DP:PL & 0/0:25:45:25:0,42,630 \\
+1 & 4370 & . & G & $<$*$>$ & . & . & LEN=14 & GT:DP:GQ:MIN\_DP:PL & 0/0:25:60:23:0,60,900 \\
+1 & 4384 & . & C & $<$*$>$ & . & . & LEN=5 & GT:DP:GQ:MIN\_DP:PL & 0/0:25:45:25:0,42,630 \\
 1 & 4389 & . & T & TC,$<$*$>$ & 213.73 & . & . & GT:DP:GQ:PL & 0/1:23:99:51,0,36,93,92,86 \\
-1 & 4390 & . & C & $<$*$>$ & . & . & END=4390 & GT:DP:GQ:MIN\_DP:PL & 0/0:26:0:26:0,0,315 \\
-1 & 4391 & . & C & $<$*$>$ & . & . & END=4395 & GT:DP:GQ:MIN\_DP:PL & 0/0:27:63:27:0,63,945 \\
+1 & 4390 & . & C & $<$*$>$ & . & . & LEN=1 & GT:DP:GQ:MIN\_DP:PL & 0/0:26:0:26:0,0,315 \\
+1 & 4391 & . & C & $<$*$>$ & . & . & LEN=5 & GT:DP:GQ:MIN\_DP:PL & 0/0:27:63:27:0,63,945 \\
 1 & 4396 & . & G & C,$<$*$>$ & 0 & . & . & GT:DP:GQ:P & 0/0:24:52:0,52,95,66,95,97 \\
-1 & 4397 & . & T & $<$*$>$ & . & . & END=4416 & GT:DP:GQ:MIN\_DP:PL & 0/0:22:14:22:0,15,593 \\
+1 & 4397 & . & T & $<$*$>$ & . & . & LEN=20 & GT:DP:GQ:MIN\_DP:PL & 0/0:22:14:22:0,15,593 \\
 \end{tabular}
 \end{flushleft}
 \normalsize
@@ -2060,6 +2069,7 @@ BCF2 files are expected to be indexed through the same index scheme, section~4 a
 
 \subsection{Changes between VCFv4.4 and VCFv4.3}
 \begin{itemize}
+\item END INFO field deprecated and replaced with LEN
 \item Started new Draft Spec
 \end{itemize}
 

--- a/VCFv4.4.draft.tex
+++ b/VCFv4.4.draft.tex
@@ -881,7 +881,7 @@ VCF STRUCTURAL VARIANT EXAMPLE
 ##FORMAT=<ID=CN,Number=1,Type=Integer,Description="Copy number genotype for imprecise events">
 ##FORMAT=<ID=CNQ,Number=1,Type=Float,Description="Copy number genotype quality for imprecise events">
 #CHROM POS     ID        REF              ALT          QUAL FILTER INFO                                                               FORMAT       NA00001
-1      2827694 rs2376870 CGTGGATGCGGGGAC  C            .    PASS   SVTYPE=DEL;LEN=15;2827708;HOMLEN=1;HOMSEQ=G;SVLEN=-14                 GT:GQ        1/1:14
+1      2827694 rs2376870 CGTGGATGCGGGGAC  C            .    PASS   SVTYPE=DEL;LEN=15;HOMLEN=1;HOMSEQ=G;SVLEN=-14                 GT:GQ        1/1:14
 2       321682 .         T                <DEL>        6    PASS   SVTYPE=DEL;LEN=206;SVLEN=-205;CIPOS=-56,20;CIEND=-10,62         GT:GQ        0/1:12
 2     14477084 .         C                <DEL:ME:ALU> 12   PASS   SVTYPE=DEL;LEN=298;SVLEN=-297;CIPOS=-22,18;CIEND=-12,32       GT:GQ        0/1:12
 3      9425916 .         C                <INS:ME:L1>  23   PASS   SVTYPE=INS;LEN=1;SVLEN=6027;CIPOS=-16,22                     GT:GQ        1/1:15


### PR DESCRIPTION
As discussed on the calls this is PR to deprecate the END field in VCF 4.4 and replace it with a new LEN field.  This would be a breaking change that requires special support in vcf libraries.  The benefits are that it should be easier to use and less error prone.  It should also compress better although as an INFO field this isn't a huge deal.   It matches the proposed RBS field better than END does as well.

LEN may not be the right name, I'm happy to change it.