### PR TITLE
Compute BIN for zero-consumption CIGARs as for unmapped reads

### DIFF
--- a/SAMv1.tex
+++ b/SAMv1.tex
@@ -1084,7 +1084,7 @@ Section~\ref{sec:recommended-practice}) and reads whose {\sf CIGAR} strings
 consume no reference bases at all, the alignment is treated as
 being of length one.
 Note unmapped reads with {\sf POS} $0$ (which becomes $-1$ in BAM) therefore
-use $\mbox{\sf reg2bin}(-1, 0)$ which is $4680$.
+use $\mbox{\sf reg2bin}(-1, 0)$ which is computed as $4680$.
 
 \subsubsection{N\_CIGAR\_OP field}\label{sec:ncigar}
 With 16 bits, {\sf n\_cigar\_op} can keep at most 65535 CIGAR
@@ -1345,6 +1345,14 @@ The following functions compute bin numbers and overlaps for a BAI-style
 binning scheme with $6$~levels and a minimum bin size of $2^{14}$~bp.
 See the CSI specification for generalisations of these functions designed for
 binning schemes with arbitrary depth and sizes.
+
+When these functions are called with regions representing unplaced
+unmapped reads, e.g., $\mbox{\sf reg2bin}(-1, 0)$, they involve operations
+such as \verb|(-1)>>14| which are undefined or implementation-defined in
+some programming languages.
+They must be implemented as if these operations use the common
+two's-complement semantics: $\mbox{\sf reg2bin}(-1, 0) = 4680$ and
+$\mbox{\sf reg2bins}(-1, 0, \ldots)$ returns $[\,0, 0, 8, 72, 584, 4680\,]$.
 
 {\small
 \begin{verbatim}

--- a/SAMv1.tex
+++ b/SAMv1.tex
@@ -1077,13 +1077,14 @@ those marked ``\textit{limited}'' are limited by available memory and the practi
 \subsubsection{BIN field calculation}\label{sec:bin-field}
 {\sf BIN} is calculated using the {\sf reg2bin()} function in
 Section~\ref{sec:code}.
-For mapped reads this uses {\sf POS-1} (i.e.,~0-based left position) and the
+For mapped reads this uses $\mbox{\sf POS}-1$ (i.e.,~0-based left position) and the
 alignment end point using the alignment length from the {\sf CIGAR} string.
-For unmapped reads (e.g.,~paired end reads where only one part is mapped, see
-Section~\ref{sec:recommended-practice}) the alignment is treated as
-being length one.
+For unmapped reads (e.g.,~paired-end reads where only one part is mapped, see
+Section~\ref{sec:recommended-practice}) and reads whose {\sf CIGAR} strings
+consume no reference bases at all, the alignment is treated as
+being of length one.
 Note unmapped reads with {\sf POS} $0$ (which becomes $-1$ in BAM) therefore
-use {\sf reg2bin(-1, 0)} which is $4680$.
+use $\mbox{\sf reg2bin}(-1, 0)$ which is $4680$.
 
 \subsubsection{N\_CIGAR\_OP field}\label{sec:ncigar}
 With 16 bits, {\sf n\_cigar\_op} can keep at most 65535 CIGAR
@@ -1429,6 +1430,7 @@ at \url{https://github.com/samtools/hts-specs}.}
 \subsection*{1.6: 28 November 2017 to current}
 
 \begin{itemize}
+\item Bin calculation changed for alignment records whose CIGAR strings consume no reference bases: like unmapped records, they are considered to have length one (rather than zero). (Jan 2021)
 \item Correct the description of index pseudo-bins, which previously stated that {\sf ref\_beg}/{\sf ref\_end}, then named {\sf unmapped\_beg}/{\sf unmapped\_end}, include only placed unmapped reads. (Jul 2020)
 \item Add {\tt DNBSEQ} to the list of {\tt @RG PL} header tag values. (Apr 2020)
 \item Add {\tt @SQ TP} circular/linear topology header tag. (May 2019)


### PR DESCRIPTION
Like placed unmapped reads, "mapped" reads with POS set but with unorthodox CIGARs that consume no reference bases would naturally span 0 bases on the reference. We artificially consider unmapped reads to have length 1 for BIN calculation and indexing purposes, so do the same thing for these zero-consumption reads.

See samtools/samtools#1240 and PR samtools/htslib#1063 for context. These are unorthodox alignments used to represent something other than mapping to a reference (if a mapping matches no reference bases at all, on what basis was POS chosen rather than flagging the record as unmapped?), so this change does not affect typical mapped data.

However even when data doesn't particularly mean anything in an alignment context, there's nothing stopping it appearing in a BAM file and it's good for tools to be able to do the expected thing with it. So this is a similar case to unmapped reads, and IMHO it's worth making a similar special case for this similar case.