### PR TITLE
SAM: explicitly limit the TLEN field to the "primary alignment".

### DIFF
--- a/SAMv1.tex
+++ b/SAMv1.tex
@@ -562,8 +562,9 @@ Each bit is explained in the following table:
   0 when the information is unavailable. This field equals {\sf POS} at the primary line of
   the next read. If {\sf PNEXT} is 0, no assumptions can be made on
   {\sf RNEXT} and bit 0x20.
-\item {\sf TLEN}: signed observed Template LENgth. If all segments are
-  mapped to the same reference sequence, the absolute value of TLEN
+\item {\sf TLEN}: signed observed Template LENgth.
+  For primary reads where the primary alignments of all reads in the template
+  are mapped to the same reference sequence, the absolute value of TLEN
   equals the distance between the mapped end of the template and the
   mapped start of the template, inclusively (i.e., $\mbox{end}-\mbox{start}+1$).%
   \footnote{Thus a segment
@@ -1438,6 +1439,7 @@ at \url{https://github.com/samtools/hts-specs}.}
 \subsection*{1.6: 28 November 2017 to current}
 
 \begin{itemize}
+\item Clarify the meaning of TLEN when secondary alignments are present. (May 2021)
 \item Bin calculation changed for alignment records whose CIGAR strings consume no reference bases: like unmapped records, they are considered to have length one (rather than zero). (Jan 2021)
 \item Correct the description of index pseudo-bins, which previously stated that {\sf ref\_beg}/{\sf ref\_end}, then named {\sf unmapped\_beg}/{\sf unmapped\_end}, include only placed unmapped reads. (Jul 2020)
 \item Add {\tt DNBSEQ} to the list of {\tt @RG PL} header tag values. (Apr 2020)


### PR DESCRIPTION
Imagine the following scenario:

![align](https://user-images.githubusercontent.com/2210525/88195607-22a9a700-cc38-11ea-8c06-d823a8d70df9.png)

R1 and R2 form a proper pair in chromosome 1.  I refer to them as R1(p) and R2(p) sometimes before.  R2 also has a secondary alignment in another chromosome, sometimes referred to as R2(s).

The definitions from the spec as it currently stands:

> \item[Multiple mapping]
  The correct placement of a read may be ambiguous, e.g., due to repeats.  In
  this case, there may be multiple read alignments for the same read.  One of
  these alignments is considered primary.  All the other alignments have the
  secondary alignment flag set in the SAM records that represent them.  All the

>   \item For each read/contig in a SAM file, it is required that one and only
        one line associated with the read satisfies \mbox{`{\sf FLAG} {\tt \& 0x900
        == 0}'}. This line is called the \emph{primary line} of the read.

So the secondary R2 is not considered primary.  That is crystal clear.

Now let's look at PNEXT and RNEXT:

> \item {\sf RNEXT}: Reference sequence name of the primary alignment of the NEXT read in the
  template. [...]
\item {\sf PNEXT}: 1-based Position of the primary alignment of the NEXT read in the template.  [...]

So they only ever point to a primary alignment.  R1(p) and R2(p) point to each other, while R2 secondary points back to R1 primary.  (This would even be required if there is an R1 secondary mapping adjacent to R2 secondary forming a complete second template alignment, but that's another battle!)

TLEN however has no mention about primary alignments:

> \item {\sf TLEN}: signed observed Template LENgth. If all segments are
  mapped to the same reference sequence, the absolute value of TLEN
  equals the distance between the mapped end of the template and the
  mapped start of the template, inclusively [...]

It just talks about _all segments_.   This is a bit confusing.  A read is what comes off the sequencing instrument, which may contain one or more segments.  Thus for our purposes we start with two segments (read 1 and read 2).   Segment however isn't defined to be the original sequence data, but just a contigous sequence or sub-sequence.  If we have a chimeric alignment then I assume we may have multiple segments, although it confusingly switches to start talking about records instead.  However to me this implies a segment is an alignment and not the source material, and thus we can have as many segments as there are alignment records. 

Under that interpretation, our secondary alignment gives us 3 segments in play.  R1(p), R2(p) and R2(s).

Now you can see the problem.  TLEN is only valid when all segments match to the same chromosome, which they do not.  The fact we had a secondary alignment elsewhere has invalidated TLEN even for the two primary alignments.

My fix therefore is to change the wording to "If all segments in the primary alignment are"...

This doesn't however do much to explain what the TLEN field should be for the secondary alignment, but this is covered later on with:

>   It is set as 0 for a single-segment template or when the
  information is unavailable (e.g., when the first or last segment
  of a multi-segment template is unmapped or when the two are mapped
  to different reference sequences).

Arguably that could be expanded to make it explicit by adding to the "or" clause with "or this alignment record is non-primary".

This does however forbid TLEN from appearing in any secondary template pairs, but like I say that's a separate battle and we already have problems there with RNEXT / PNEXT being dictated to only ever point to primary alignments.  I'm sort of resigned to never managing to resolve that one as the desire for any review is zero. :/

Comments?