### PR TITLE
document convention for "QC squeezing" in population VCF

### DIFF
--- a/VCFv4.4.draft.tex
+++ b/VCFv4.4.draft.tex
@@ -1409,6 +1409,11 @@ Example records are given below:
 \end{flushleft}
 \normalsize
 
+\subsection{Selective genotype fields in many-sample VCF}
+In VCF data representing SNPs and small indels jointly discovered and genotyped across a population, typically the vast majority of genotype fields are homozygous for the reference allele (0/0). When these GT entries are accompanied by the full array of quality-control FORMAT fields supporting variant genotypes (e.g. AD, SB, PL), the resulting file size may grow disproportionately to the practical utility of these fields.
+
+To ameliorate this, joint variant calling tools may opt to order FORMAT fields so that most of them can be omitted in most entries (invoking the previous clause, ``Trailing [FORMAT] fields can be dropped, with the exception of the GT field''). For example, the FORMAT fields might be ordered {\tt GT:DP:AD:SB:PL} so that entries lacking significant evidence of variation may write GT and DP only (e.g. {\tt 0/0:32}). DP might furthermore be binned in some way, to improve compressibility. Tools consuming many-sample VCF files should accommodate this convention.
+
 \pagebreak
 \section{BCF specification}
 


### PR DESCRIPTION
This PR documents a convention developed in [spVCF](https://github.com/mlin/spVCF) to reduce the size of population-wide VCF files (presenting the full locus x sample matrix) by selectively omitting FORMAT fields. As written, **this is not a spec change** but merely suggests a useful invocation of an existing clause (referenced inline). We suggest it may be worth documenting expressly because we've encountered some downstream tools that do get tripped up by it.

In our experiments, applying this convention to WGS/WES VCF files for cohorts like 1KGP and UKB (generated with different pipelines) delivers 4-6X file size reduction without doing anything else.

Related PRs:

* #435 suggests a way to encode the matrix sparsely, implemented in the [Hail VCF Combiner](https://hail.is/docs/0.2/experimental/vcf_combiner.html). spVCF has a different sparse encoding, and both approaches have distinctive merits (#435 is more natural when GVCF files are the conceptual point of departure; spVCF's is more natural when starting from a population VCF file). Both require substantial work on existing VCF parsers to interpret correctly, especially for tabix-style random access.<br/>The convention suggested here complements either approach, with a cheap way to "densify" the sparsely-encoded matrix so that it's much easier for existing tools to consume (perhaps with minor fixes, if they don't honor the existing spec clause). Furthermore if we know this is the endpoint, then we may be able to encode the matrix "even more" sparsely.
* #434 and more recent discussion about the star allele (#437 #464) suggest ways of dealing with multiallelic loci, another principal source of excessive population VCF file size growth. The convention here delivers partial value by omitting AD and PL in most entries, which may reduce the urgency, while certainly not eliminating.
