### PR TITLE
Expand introduction to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 SAM/BAM and related specifications
 ==================================
 
+These documents are maintained by the Large Scale Genomics work stream of the Global Alliance for Genomics & Health ([GA4GH][GA4GH.org]).
+Information on GA4GH procedures and how to get involved is [available here][LSG-wiki].
+Lists of contributors and acknowledgements can generally be found in each individual specification document.
+
 Links **in bold** point to the corresponding PDFs on this repository's [GitHub Pages website][hts-specs].
 
 Please request improvements or report errors using this repository, but see also [the list of maintainers](MAINTAINERS.md) if you need to contact them directly.
@@ -14,7 +18,7 @@ Alignment data files
 These formats are discussed on the [samtools-devel mailing list][samdev-ml].
 
 **[CRAMv3.tex]** is the canonical specification for the CRAM format, while **[CRAMv2.1.tex]** describes its now-obsolete predecessor.
-Further details can be found at [ENA's CRAM toolkit page][ena-cram].
+Further details can be found at [ENA's CRAM toolkit page][ena-cram] and [GA4GH's CRAM page][ga4gh-cram].
 CRAM discussions can also be found on the [samtools-devel mailing list][samdev-ml].
 
 The **[tabix.tex]** and **[CSIv1.tex]** quick references summarize more recent index formats: the tabix tool indexes generic textual genome position-sorted files, while CSI is [htslib]'s successor to the BAI index format.
@@ -53,6 +57,9 @@ Transfer protocols
 
 **[Refget.md]** enables access to reference sequences using an identifier derived from the sequence itself.
 
+[GA4GH.org]:    https://www.ga4gh.org/
+[LSG-wiki]:     https://github.com/ga4gh/large-scale-genomics-wiki/wiki
+
 [SAMv1.tex]:    http://samtools.github.io/hts-specs/SAMv1.pdf
 [SAMtags.tex]:  http://samtools.github.io/hts-specs/SAMtags.pdf
 [CRAMv2.1.tex]: http://samtools.github.io/hts-specs/CRAMv2.1.pdf
@@ -70,6 +77,7 @@ Transfer protocols
 [Refget.md]:    https://samtools.github.io/hts-specs/refget.html
 
 [ena-cram]:   http://www.ebi.ac.uk/ena/about/cram_toolkit
+[ga4gh-cram]: https://www.ga4gh.org/cram/
 [htslib]:     https://github.com/samtools/htslib
 [samtools]:   https://github.com/samtools/samtools
 [hts-specs]:  http://samtools.github.io/hts-specs/

--- a/index.md
+++ b/index.md
@@ -7,7 +7,7 @@ title: HTS format specifications
 {% capture readme %}{% include_relative README.md %}{% endcapture %}
 {% assign readme_lines = readme | split: newline %}
 
-{% for line in readme_lines limit: 2 %}
+{% for line in readme_lines limit: 6 %}
 {{line}}{% endfor %}
 
 <div class="sidebar lowered">
@@ -30,7 +30,7 @@ Specifications:
 - [Refget](refget.html)
 </div>
 <div class="mainbar">
-{% for line in readme_lines offset: 8 %}
+{% for line in readme_lines offset: 12 %}
 {{line}}{% endfor %}
 </div>
 <div class="clear"></div>


### PR DESCRIPTION
- GA4GH now gets a mention in the introduction.  This links over to the main site as well as the github ga4gh wiki as this has much more information on how we work, minutes, and other LSG projects not in this repository (RNAget).  I am aware the GA4GH web site may get revamped at some point, but we can update again if/when this happens.

- A contributors section has been added at the end.  This is "thin", but it's a start.  I encourage each specification maintainer to look to adding contributors sections to their relevant specs if not already done.