### PR TITLE
strawman attempt at adding array of booleans to VCF

### DIFF
--- a/VCFv4.3.tex
+++ b/VCFv4.3.tex
@@ -151,7 +151,10 @@ There are also certain special characters used to define special cases:
   \item . (dot): The number of possible values varies, is unknown or unbounded.
 \end{itemize}
 
-The `Flag' type indicates that the INFO field does not contain a Value entry, and hence the Number must be $0$ in this case.
+The `Flag' type can indicate a single boolean value, or an array of boolean values. 
+To indicate one boolean value it can be defined with Number=$0$ and in this case the presence of the field tag indicates a "true" value, and its absence indicates a "false" value. 
+Alternatively, Number can take on other values (including 1) as described above. In that case the value of 1 will indicate "true" and 0 will indicate "false".
+
 The Description value must be surrounded by double-quotes.
 Double-quote character must be escaped with backslash $\backslash$ and backslash as $\backslash\backslash$.
 Source and Version values likewise must be surrounded by double-quotes and specify the annotation source (case-insensitive, e.g.\ \verb|"dbsnp"|) and exact version (e.g.\ \verb|"138"|), respectively for computational use.


### PR DESCRIPTION
This is just a first draft, once the wording is finalized, I intend to:

- [ ] modify VCFv4.4 as well
- [ ] add and entry to the change logs

The point of this change is to allow an INFO (or FORMAT) field to contain an arrays of boolean values. 

it maintains the old behavior so that a Number of "0" would indicate that the presence of the field is "true" and its absence, "false". but it also allow all the other Number options, and in that case, 0 will indicate "false" while 1 will indicate "true". 

