### PR TITLE
Add subtitles noting VCF v4.1 & v4.2 have been superseded by a later version

### DIFF
--- a/VCFv4.1.tex
+++ b/VCFv4.1.tex
@@ -7,7 +7,9 @@
 
 \begin{document}
 \input{VCFv4.1.ver}
-\title{The Variant Call Format (VCF) Version 4.1 Specification}
+\title{The Variant Call Format (VCF) Version 4.1 Specification
+\normalsize\\[2ex]
+(Superseded by the \href{http://samtools.github.io/hts-specs/VCFv4.2.pdf}{VCF v4.2} and \href{http://samtools.github.io/hts-specs/VCFv4.3.pdf}{v4.3} specifications)}
 \date{\headdate}
 \maketitle
 \begin{quote}\small

--- a/VCFv4.2.tex
+++ b/VCFv4.2.tex
@@ -7,7 +7,9 @@
 
 \begin{document}
 \input{VCFv4.2.ver}
-\title{The Variant Call Format (VCF) Version 4.2 Specification}
+\title{The Variant Call Format (VCF) Version 4.2 Specification
+\normalsize\\[2ex]
+(Superseded by the \href{http://samtools.github.io/hts-specs/VCFv4.3.pdf}{VCF v4.3} specification introduced in October 2015)}
 \date{\headdate}
 \maketitle
 \begin{quote}\small


### PR DESCRIPTION
These older specifications currently have no mention of the later VCF specification that supersedes them. This adds such a note on the title page.

The October 2015 date comes from c8194c65a10b9487ab5b65be0ec75a6f11b3005b.