### PR TITLE
Add note about link expiry for pdf_comment

### DIFF
--- a/.circleci/pdf_comment.js
+++ b/.circleci/pdf_comment.js
@@ -41,7 +41,7 @@ var text=`Changed PDFs as of ${ls.stdout.toString().trim()}:`
 text += fs.readdirSync("diff")
 	.filter(s=>s.match(".pdf$"))
 	.map(s=>s.replace(".pdf",""))
-	.map(file => addLink(file)).join(",")+".";
+	.map(file => addLink(file)).join(",")+". This link will expire in 30 days";
 
 console.log(text)
 bot.comment(process.env.GH_AUTH_TOKEN, text)


### PR DESCRIPTION
This is just a note for the hts-specs-bot PDF links to give notice to their expiring. Just an add-on to #555  to let users/browsers of the PRs that the link is expected to expire