### PR TITLE
Clarify the the source of the contig in VCF

### DIFF
--- a/VCFv4.1.tex
+++ b/VCFv4.1.tex
@@ -1056,8 +1056,8 @@ The CHROM field in BCF2 is encoded as an integer offset into the list of \verb|#
 \small
 \begin{verbatim}
 ##contig=<ID=20,length=62435964,assembly=B36,md5=f126cdf8a6e0c7f379d618ff66beb2da,species="Homo sapiens">
-##contig=<ID=21,length=62435964,assembly=B36,md5=f126cdf8a6e0c7f379d618ff66beb2da,species="Homo sapiens">
-##contig=<ID=22,length=62435964,assembly=B36,md5=f126cdf8a6e0c7f379d618ff66beb2da,species="Homo sapiens">
+##contig=<ID=21,length=46944323,assembly=B36,md5=f1b74b7f9f4cdbaeb6832ee86cb426c6,species="Homo sapiens">
+##contig=<ID=22,length=49691432,assembly=B36,md5=2041e6a0c914b48dd537922cca63acb8,species="Homo sapiens">
 #CHROM POS ID REF ALT QUAL FILTER INFO
 20 1 . T A . PASS .
 21 2 . T A . PASS .

--- a/VCFv4.2.tex
+++ b/VCFv4.2.tex
@@ -1073,8 +1073,8 @@ The CHROM field in BCF2 is encoded as an integer offset into the list of \verb|#
 \small
 \begin{verbatim}
 ##contig=<ID=20,length=62435964,assembly=B36,md5=f126cdf8a6e0c7f379d618ff66beb2da,species="Homo sapiens">
-##contig=<ID=21,length=62435964,assembly=B36,md5=f126cdf8a6e0c7f379d618ff66beb2da,species="Homo sapiens">
-##contig=<ID=22,length=62435964,assembly=B36,md5=f126cdf8a6e0c7f379d618ff66beb2da,species="Homo sapiens">
+##contig=<ID=21,length=46944323,assembly=B36,md5=f1b74b7f9f4cdbaeb6832ee86cb426c6,species="Homo sapiens">
+##contig=<ID=22,length=49691432,assembly=B36,md5=2041e6a0c914b48dd537922cca63acb8,species="Homo sapiens">
 #CHROM POS ID REF ALT QUAL FILTER INFO
 20 1 . T A . PASS .
 21 2 . T A . PASS .

--- a/VCFv4.3.tex
+++ b/VCFv4.3.tex
@@ -223,7 +223,7 @@ The structured \texttt{contig} field must include the ID attribute and can inclu
 the following ones reserved:
 \begin{itemize}
   \item length: the length of the sequence
-  \item md5: MD5 checksum of the sequence as defined in the Sam specification v1\footnote{See Reference MD5 calculation
+  \item md5: MD5 checksum of the sequence as defined in SAM's {\tt @SQ-M5} field\footnote{See Reference MD5 calculation
       section in \href{https://samtools.github.io/hts-specs/SAMv1.pdf}{\tt SAM Format Specification}.} Briefly, the digest
       is calculated excluding all characters outside of the inclusive range 33 (`\char33') to 126 (`\char126')
       and all lowercase characters converted to uppercase. The MD5 digest is calculated as described in

--- a/VCFv4.3.tex
+++ b/VCFv4.3.tex
@@ -224,8 +224,8 @@ the following ones reserved:
 \begin{itemize}
   \item length: the length of the sequence
   \item md5: MD5 checksum of the sequence as defined in the Sam specification v1\footnote{See Reference MD5 calculation
-      section in \href{https://github.com/samtools/hts-specs/blob/master/SAMv1.pdf}{\tt SAMv1.pdf}.} Briefly, the digest
-      is calculated including all characters outside of the inclusive range 33 (`\char33') to 126 (`\char126').
+      section in \href{https://samtools.github.io/hts-specs/SAMv1.pdf}{\tt SAMv1.pdf}.} Briefly, the digest
+      is calculated excluding all characters outside of the inclusive range 33 (`\char33') to 126 (`\char126')
       and all lowercase characters converted to uppercase. The MD5 digest is calculated as described in
       \href{https://tools.ietf.org/html/rfc1321}{\sl RFC 1321} and presented as a 32 character lowercase hexadecimal number.
   \item URL: tag to indicate where the sequence can be found

--- a/VCFv4.3.tex
+++ b/VCFv4.3.tex
@@ -224,7 +224,7 @@ the following ones reserved:
 \begin{itemize}
   \item length: the length of the sequence
   \item md5: MD5 checksum of the sequence as defined in the Sam specification v1\footnote{See Reference MD5 calculation
-      section in \href{https://samtools.github.io/hts-specs/SAMv1.pdf}{\tt SAMv1.pdf}.} Briefly, the digest
+      section in \href{https://samtools.github.io/hts-specs/SAMv1.pdf}{\tt SAM Format Specification}.} Briefly, the digest
       is calculated excluding all characters outside of the inclusive range 33 (`\char33') to 126 (`\char126')
       and all lowercase characters converted to uppercase. The MD5 digest is calculated as described in
       \href{https://tools.ietf.org/html/rfc1321}{\sl RFC 1321} and presented as a 32 character lowercase hexadecimal number.

--- a/VCFv4.3.tex
+++ b/VCFv4.3.tex
@@ -232,10 +232,11 @@ the following ones reserved:
 \end{itemize}
 
 For example:
+{\scriptsize
 \begin{verbatim}
-##contig=<ID=ctg1,length=81195210,URL=ftp://somewhere.org/assembly.fa,md5=f126cdf8a6e0c7f379d618ff66beb2da,...>
+##contig=<ID=ctg1,length=81195210,URL=ftp://example.com/assembly.fa,md5=f126cdf8a6e0c7f379d618ff66beb2da,...>
 \end{verbatim}
-
+}
 \noindent
 Contig names follow the same rules as the SAM format's reference sequence names:
 they may contain any printable ASCII characters in the range \verb|[!-~]| apart from `{\tt\verb|\|\,,\,"`'\,()\,[]\,\verb|{}|\,<>}' and may not start with `{\tt *}' or `{\tt =}'.

--- a/VCFv4.3.tex
+++ b/VCFv4.3.tex
@@ -219,7 +219,7 @@ The URL field specifies the location of a fasta file containing breakpoint assem
 \subsubsection{Contig field format}
 \label{sec-contig-field}
 It is recommended for VCF, and required for BCF, that the header includes tags describing the contigs referred to in the file.
-The structured \texttt{contig} field must include the ID attribute and typically includes also sequence length, MD5 checksum, URL tag to indicate where the sequence can be found, etc.
+The structured \texttt{contig} field must include the ID attribute and typically includes also sequence length, MD5 checksum of the sequence as defined in the \href{https://github.com/samtools/hts-specs/blob/master/refget.md}{Refget specification}, URL tag to indicate where the sequence can be found, etc.
 For example:
 \begin{verbatim}
 ##contig=<ID=ctg1,length=81195210,URL=ftp://somewhere.org/assembly.fa,...>
@@ -1514,8 +1514,8 @@ Here's a more concrete example:
 \small
 \begin{verbatim}
 ##contig=<ID=20,length=62435964,assembly=B36,md5=f126cdf8a6e0c7f379d618ff66beb2da,species="Homo sapiens">
-##contig=<ID=21,length=62435964,assembly=B36,md5=f126cdf8a6e0c7f379d618ff66beb2da,species="Homo sapiens">
-##contig=<ID=22,length=62435964,assembly=B36,md5=f126cdf8a6e0c7f379d618ff66beb2da,species="Homo sapiens">
+##contig=<ID=21,length=46944323,assembly=B36,md5=f1b74b7f9f4cdbaeb6832ee86cb426c6,species="Homo sapiens">
+##contig=<ID=22,length=49691432,assembly=B36,md5=2041e6a0c914b48dd537922cca63acb8,species="Homo sapiens">
 #CHROM POS ID REF ALT QUAL FILTER INFO
 20 1 . T A . PASS .
 21 2 . T A . PASS .

--- a/VCFv4.3.tex
+++ b/VCFv4.3.tex
@@ -219,10 +219,21 @@ The URL field specifies the location of a fasta file containing breakpoint assem
 \subsubsection{Contig field format}
 \label{sec-contig-field}
 It is recommended for VCF, and required for BCF, that the header includes tags describing the contigs referred to in the file.
-The structured \texttt{contig} field must include the ID attribute and typically includes also sequence length, MD5 checksum of the sequence as defined in the \href{https://github.com/samtools/hts-specs/blob/master/refget.md}{Refget specification}, URL tag to indicate where the sequence can be found, etc.
+The structured \texttt{contig} field must include the ID attribute and can includes additional optional fields with
+the following fields reserved:
+\begin{itemize}
+  \item length: the length of the sequence
+  \item md5: MD5 checksum of the sequence as defined in the Sam specification v1\footnote{See Reference MD5 calculation
+      section in \href{https://github.com/samtools/hts-specs/blob/master/SAMv1.pdf}{\tt SAMv1.pdf}.} Briefly, the digest
+      is calculated including all characters outside of the inclusive range 33 (`\char33') to 126 (`\char126').
+      and all lowercase characters converted to uppercase. The MD5 digest is calculated as described in
+      \href{https://tools.ietf.org/html/rfc1321}{\sl RFC 1321} and presented as a 32 character lowercase hexadecimal number.
+  \item URL: tag to indicate where the sequence can be found
+\end{itemize}
+
 For example:
 \begin{verbatim}
-##contig=<ID=ctg1,length=81195210,URL=ftp://somewhere.org/assembly.fa,...>
+##contig=<ID=ctg1,length=81195210,URL=ftp://somewhere.org/assembly.fa, md5=f126cdf8a6e0c7f379d618ff66beb2da, ...>
 \end{verbatim}
 
 \noindent

--- a/VCFv4.3.tex
+++ b/VCFv4.3.tex
@@ -219,8 +219,8 @@ The URL field specifies the location of a fasta file containing breakpoint assem
 \subsubsection{Contig field format}
 \label{sec-contig-field}
 It is recommended for VCF, and required for BCF, that the header includes tags describing the contigs referred to in the file.
-The structured \texttt{contig} field must include the ID attribute and can includes additional optional fields with
-the following fields reserved:
+The structured \texttt{contig} field must include the ID attribute and can includes additional optional attributes with
+the following ones reserved:
 \begin{itemize}
   \item length: the length of the sequence
   \item md5: MD5 checksum of the sequence as defined in the Sam specification v1\footnote{See Reference MD5 calculation
@@ -233,7 +233,7 @@ the following fields reserved:
 
 For example:
 \begin{verbatim}
-##contig=<ID=ctg1,length=81195210,URL=ftp://somewhere.org/assembly.fa, md5=f126cdf8a6e0c7f379d618ff66beb2da, ...>
+##contig=<ID=ctg1,length=81195210,URL=ftp://somewhere.org/assembly.fa,md5=f126cdf8a6e0c7f379d618ff66beb2da,...>
 \end{verbatim}
 
 \noindent

--- a/VCFv4.4.draft.tex
+++ b/VCFv4.4.draft.tex
@@ -224,11 +224,21 @@ The URL field specifies the location of a fasta file containing breakpoint assem
 \subsubsection{Contig field format}
 \label{sec-contig-field}
 It is recommended for VCF, and required for BCF, that the header includes tags describing the contigs referred to in the file.
-The structured \texttt{contig} field must include the ID attribute and typically includes also sequence length, MD5 checksum of the sequence as defined in the \href{https://github.com/samtools/hts-specs/blob/master/refget.md}{Refget specification}, URL tag to indicate where the sequence can be found, etc.
+The structured \texttt{contig} field must include the ID attribute and can includes additional optional fields with
+the following fields reserved:
+\begin{itemize}
+  \item length: the length of the sequence
+  \item md5: MD5 checksum of the sequence as defined in the Sam specification v1\footnote{See Reference MD5 calculation
+      section in \href{https://github.com/samtools/hts-specs/blob/master/SAMv1.pdf}{\tt SAMv1.pdf}.} Briefly, the digest
+      is calculated including all characters outside of the inclusive range 33 (`\char33') to 126 (`\char126').
+      and all lowercase characters converted to uppercase. The MD5 digest is calculated as described in
+      \href{https://tools.ietf.org/html/rfc1321}{\sl RFC 1321} and presented as a 32 character lowercase hexadecimal number.
+  \item URL: tag to indicate where the sequence can be found
+\end{itemize}
+
 For example:
 \begin{verbatim}
-##contig=<ID=ctg1,length=81195210,URL=ftp://somewhere.org/assembly.fa,...>
-\end{verbatim}
+##contig=<ID=ctg1,length=81195210,URL=ftp://somewhere.org/assembly.fa, md5=f126cdf8a6e0c7f379d618ff66beb2da, ...>
 
 \noindent
 Contig names follow the same rules as the SAM format's reference sequence names:

--- a/VCFv4.4.draft.tex
+++ b/VCFv4.4.draft.tex
@@ -229,8 +229,8 @@ the following ones reserved:
 \begin{itemize}
   \item length: the length of the sequence
   \item md5: MD5 checksum of the sequence as defined in the Sam specification v1\footnote{See Reference MD5 calculation
-      section in \href{https://github.com/samtools/hts-specs/blob/master/SAMv1.pdf}{\tt SAMv1.pdf}.} Briefly, the digest
-      is calculated including all characters outside of the inclusive range 33 (`\char33') to 126 (`\char126').
+      section in \href{https://samtools.github.io/hts-specs/SAMv1.pdf}{\tt SAMv1.pdf}.} Briefly, the digest
+      is calculated excluding all characters outside of the inclusive range 33 (`\char33') to 126 (`\char126').
       and all lowercase characters converted to uppercase. The MD5 digest is calculated as described in
       \href{https://tools.ietf.org/html/rfc1321}{\sl RFC 1321} and presented as a 32 character lowercase hexadecimal number.
   \item URL: tag to indicate where the sequence can be found

--- a/VCFv4.4.draft.tex
+++ b/VCFv4.4.draft.tex
@@ -229,7 +229,7 @@ the following ones reserved:
 \begin{itemize}
   \item length: the length of the sequence
   \item md5: MD5 checksum of the sequence as defined in the Sam specification v1\footnote{See Reference MD5 calculation
-      section in \href{https://samtools.github.io/hts-specs/SAMv1.pdf}{\tt SAMv1.pdf}.} Briefly, the digest
+      section in \href{https://samtools.github.io/hts-specs/SAMv1.pdf}{\tt SAM Format Specification}.} Briefly, the digest
       is calculated excluding all characters outside of the inclusive range 33 (`\char33') to 126 (`\char126').
       and all lowercase characters converted to uppercase. The MD5 digest is calculated as described in
       \href{https://tools.ietf.org/html/rfc1321}{\sl RFC 1321} and presented as a 32 character lowercase hexadecimal number.
@@ -240,6 +240,7 @@ For example:
 \begin{verbatim}
 ##contig=<ID=ctg1,length=81195210,URL=ftp://somewhere.org/assembly.fa,md5=f126cdf8a6e0c7f379d618ff66beb2da,...>
 \end{verbatim}
+
 \noindent
 Contig names follow the same rules as the SAM format's reference sequence names:
 they may contain any printable ASCII characters in the range \verb|[!-~]| apart from `{\tt\verb|\|\,,\,"`'\,()\,[]\,\verb|{}|\,<>}' and may not start with `{\tt *}' or `{\tt =}'.

--- a/VCFv4.4.draft.tex
+++ b/VCFv4.4.draft.tex
@@ -239,7 +239,7 @@ the following ones reserved:
 For example:
 \begin{verbatim}
 ##contig=<ID=ctg1,length=81195210,URL=ftp://somewhere.org/assembly.fa,md5=f126cdf8a6e0c7f379d618ff66beb2da,...>
-
+\end{verbatim}
 \noindent
 Contig names follow the same rules as the SAM format's reference sequence names:
 they may contain any printable ASCII characters in the range \verb|[!-~]| apart from `{\tt\verb|\|\,,\,"`'\,()\,[]\,\verb|{}|\,<>}' and may not start with `{\tt *}' or `{\tt =}'.

--- a/VCFv4.4.draft.tex
+++ b/VCFv4.4.draft.tex
@@ -224,7 +224,7 @@ The URL field specifies the location of a fasta file containing breakpoint assem
 \subsubsection{Contig field format}
 \label{sec-contig-field}
 It is recommended for VCF, and required for BCF, that the header includes tags describing the contigs referred to in the file.
-The structured \texttt{contig} field must include the ID attribute and typically includes also sequence length, MD5 checksum, URL tag to indicate where the sequence can be found, etc.
+The structured \texttt{contig} field must include the ID attribute and typically includes also sequence length, MD5 checksum of the sequence as defined in the \href{https://github.com/samtools/hts-specs/blob/master/refget.md}{Refget specification}, URL tag to indicate where the sequence can be found, etc.
 For example:
 \begin{verbatim}
 ##contig=<ID=ctg1,length=81195210,URL=ftp://somewhere.org/assembly.fa,...>
@@ -1647,8 +1647,8 @@ Here's a more concrete example:
 \small
 \begin{verbatim}
 ##contig=<ID=20,length=62435964,assembly=B36,md5=f126cdf8a6e0c7f379d618ff66beb2da,species="Homo sapiens">
-##contig=<ID=21,length=62435964,assembly=B36,md5=f126cdf8a6e0c7f379d618ff66beb2da,species="Homo sapiens">
-##contig=<ID=22,length=62435964,assembly=B36,md5=f126cdf8a6e0c7f379d618ff66beb2da,species="Homo sapiens">
+##contig=<ID=21,length=46944323,assembly=B36,md5=f1b74b7f9f4cdbaeb6832ee86cb426c6,species="Homo sapiens">
+##contig=<ID=22,length=49691432,assembly=B36,md5=2041e6a0c914b48dd537922cca63acb8,species="Homo sapiens">
 #CHROM POS ID REF ALT QUAL FILTER INFO
 20 1 . T A . PASS .
 21 2 . T A . PASS .

--- a/VCFv4.4.draft.tex
+++ b/VCFv4.4.draft.tex
@@ -224,8 +224,8 @@ The URL field specifies the location of a fasta file containing breakpoint assem
 \subsubsection{Contig field format}
 \label{sec-contig-field}
 It is recommended for VCF, and required for BCF, that the header includes tags describing the contigs referred to in the file.
-The structured \texttt{contig} field must include the ID attribute and can includes additional optional fields with
-the following fields reserved:
+The structured \texttt{contig} field must include the ID attribute and can includes additional optional attributes with
+the following ones reserved:
 \begin{itemize}
   \item length: the length of the sequence
   \item md5: MD5 checksum of the sequence as defined in the Sam specification v1\footnote{See Reference MD5 calculation
@@ -238,7 +238,7 @@ the following fields reserved:
 
 For example:
 \begin{verbatim}
-##contig=<ID=ctg1,length=81195210,URL=ftp://somewhere.org/assembly.fa, md5=f126cdf8a6e0c7f379d618ff66beb2da, ...>
+##contig=<ID=ctg1,length=81195210,URL=ftp://somewhere.org/assembly.fa,md5=f126cdf8a6e0c7f379d618ff66beb2da,...>
 
 \noindent
 Contig names follow the same rules as the SAM format's reference sequence names:

--- a/VCFv4.4.draft.tex
+++ b/VCFv4.4.draft.tex
@@ -237,10 +237,11 @@ the following ones reserved:
 \end{itemize}
 
 For example:
+{\scriptsize
 \begin{verbatim}
 ##contig=<ID=ctg1,length=81195210,URL=ftp://somewhere.org/assembly.fa,md5=f126cdf8a6e0c7f379d618ff66beb2da,...>
 \end{verbatim}
-
+}
 \noindent
 Contig names follow the same rules as the SAM format's reference sequence names:
 they may contain any printable ASCII characters in the range \verb|[!-~]| apart from `{\tt\verb|\|\,,\,"`'\,()\,[]\,\verb|{}|\,<>}' and may not start with `{\tt *}' or `{\tt =}'.


### PR DESCRIPTION
Very small PR to clarify that the MD5 for contigs are calculated from the sequence and not the whole file
This is not addressing #551 but should clarify what is already stated