### PR TITLE
Fix `##PEDIGREE` example typographical errors

### DIFF
--- a/VCFv4.1.tex
+++ b/VCFv4.1.tex
@@ -867,13 +867,13 @@ Analogously, there might also be several normal genomes from the same patient in
 The general format of a PEDIGREE line describing asexual, clonal derivation is:
 
 \begin{verbatim}
-PEDIGREE=<Derived=ID2,Original=ID1>
+##PEDIGREE=<Derived=ID2,Original=ID1>
 \end{verbatim}
 
-This line asserts that the DNA in genome is asexually or clonally derived with mutations from the DNA in genome . This is the asexual analog of the VCF format that has been proposed for family relationships between genomes, i.e., there is one entry per of the form:
+This line asserts that the DNA in genome ID2 is asexually or clonally derived with mutations from the DNA in genome ID1. This is the asexual analog of the VCF format that has been proposed for family relationships between genomes, i.e., there is one entry per trio of the form:
 
 \begin{verbatim}
-PEDIGREE=<Child=CHILD-GENOME-ID,Mother=MOTHER-GENOME-ID,Father=FATHER-GENOME-ID>
+##PEDIGREE=<Child=CHILD-GENOME-ID,Mother=MOTHER-GENOME-ID,Father=FATHER-GENOME-ID>
 \end{verbatim}
 
 Let's consider a cancer patient VCF file with 4 genomes: germline, primary\_tumor, secondary\_tumor1, and secondary\_tumor2 as illustrated in Figure 10. The primary\_tumor is derived from the germline and the secondary tumors are each derived independently from the primary tumor, in all cases by clonal derivation with mutations. The PEDIGREE lines would look like:

--- a/VCFv4.2.tex
+++ b/VCFv4.2.tex
@@ -884,13 +884,13 @@ Analogously, there might also be several normal genomes from the same patient in
 The general format of a PEDIGREE line describing asexual, clonal derivation is:
 
 \begin{verbatim}
-PEDIGREE=<Derived=ID2,Original=ID1>
+##PEDIGREE=<Derived=ID2,Original=ID1>
 \end{verbatim}
 
-This line asserts that the DNA in genome ID2 is asexually or clonally derived with mutations from the DNA in genome ID1. This is the asexual analog of the VCF format that has been proposed for family relationships between genomes, i.e., there is one entry per of the form:
+This line asserts that the DNA in genome ID2 is asexually or clonally derived with mutations from the DNA in genome ID1. This is the asexual analog of the VCF format that has been proposed for family relationships between genomes, i.e., there is one entry per trio of the form:
 
 \begin{verbatim}
-PEDIGREE=<Child=CHILD-GENOME-ID,Mother=MOTHER-GENOME-ID,Father=FATHER-GENOME-ID>
+##PEDIGREE=<Child=CHILD-GENOME-ID,Mother=MOTHER-GENOME-ID,Father=FATHER-GENOME-ID>
 \end{verbatim}
 
 Let's consider a cancer patient VCF file with 4 genomes: germline, primary\_tumor, secondary\_tumor1, and secondary\_tumor2 as illustrated in Figure 10. The primary\_tumor is derived from the germline and the secondary tumors are each derived independently from the primary tumor, in all cases by clonal derivation with mutations. The PEDIGREE lines would look like:

--- a/VCFv4.3.tex
+++ b/VCFv4.3.tex
@@ -1277,14 +1277,14 @@ These normal genomes are then considered to be derived from the original germlin
 The general format of a PEDIGREE line describing asexual, clonal derivation is:
 
 \begin{verbatim}
-PEDIGREE=<ID=DerivedID,Original=OriginalID>
+##PEDIGREE=<ID=DerivedID,Original=OriginalID>
 \end{verbatim}
 
-This line asserts that the DNA in genome is asexually or clonally derived with mutations from the DNA in genome.
-This is the asexual analog of the VCF format that has been proposed for family relationships between genomes, i.e., there is one entry per of the form:
+This line asserts that the DNA in genome DerivedID is asexually or clonally derived with mutations from the DNA in genome OriginalID.
+This is the asexual analog of the VCF format that has been proposed for family relationships between genomes, i.e., there is one entry per trio of the form:
 
 \begin{verbatim}
-PEDIGREE=<ID=ChildID,Mother=MotherID,Father=FatherID>
+##PEDIGREE=<ID=ChildID,Mother=MotherID,Father=FatherID>
 \end{verbatim}
 
 Let's consider a cancer patient VCF file with 4 genomes: germline, primary\_tumor, secondary\_tumor1, and secondary\_tumor2 as illustrated in Figure 10.

--- a/VCFv4.4.draft.tex
+++ b/VCFv4.4.draft.tex
@@ -1410,14 +1410,14 @@ These normal genomes are then considered to be derived from the original germlin
 The general format of a PEDIGREE line describing asexual, clonal derivation is:
 
 \begin{verbatim}
-PEDIGREE=<ID=DerivedID,Original=OriginalID>
+##PEDIGREE=<ID=DerivedID,Original=OriginalID>
 \end{verbatim}
 
-This line asserts that the DNA in genome is asexually or clonally derived with mutations from the DNA in genome.
-This is the asexual analog of the VCF format that has been proposed for family relationships between genomes, i.e., there is one entry per of the form:
+This line asserts that the DNA in genome DerivedID is asexually or clonally derived with mutations from the DNA in genome OriginalID.
+This is the asexual analog of the VCF format that has been proposed for family relationships between genomes, i.e., there is one entry per trio of the form:
 
 \begin{verbatim}
-PEDIGREE=<ID=ChildID,Mother=MotherID,Father=FatherID>
+##PEDIGREE=<ID=ChildID,Mother=MotherID,Father=FatherID>
 \end{verbatim}
 
 Let's consider a cancer patient VCF file with 4 genomes: germline, primary\_tumor, secondary\_tumor1, and secondary\_tumor2 as illustrated in Figure 10.


### PR DESCRIPTION
PR #413 both fixed some typographical errors in `##PEDIGREE` examples and added a new section describing previously undescribed `##PEDIGREE` usage. It has been bogged down for two years as the details of the latter were debated for a while and then ignored.

This PR pulls out the first commit of that, which fixes obvious typographical errors (or possibly transcription errors from when the original g1k wiki VCF text was converted to LaTeX) in the `##PEDIGREE` examples in one section of each spec, and updates it to also fix the errors duplicated into _VCFv4.4.draft.tex_.

This PR simply fixes existing typographical errors in the VCF specs and should be able to be merged without undue delay.