### PR TITLE
File formats maintainership updates

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -9,9 +9,8 @@ The current maintainers are listed below.
 
 * James Bonfield (@jkbonfield)
 * John Marshall (@jmarshall)
-* Yossi Farjoun (@yfarjoun)
 
-Past SAM/BAM maintainers include Jay Carey, Tim Fennell, and Nils Homer.
+Past SAM/BAM maintainers include Jay Carey, Yossi Farjoun, Tim Fennell, and Nils Homer.
 
 ### CRAM
 
@@ -23,10 +22,10 @@ Past CRAM maintainers include Vadim Zalunin.
 ### VCF/BCF
 
 * Louis Bergelson (@lbergelson)
-* Petr Danecek (@pd3)
+* Daniel Cameron (@d-cameron)
 * Kirill Tsukanov (@tskir)
 
-Past VCF/BCF maintainers include Cristina Yenyxe Gonzalez Garcia, Jose Miguel Mut Lopez, Ryan Poplin, and David Roazen.
+Past VCF/BCF maintainers include Petr Danecek, Cristina Yenyxe Gonzalez Garcia, Jose Miguel Mut Lopez, Ryan Poplin, and David Roazen.
 
 ### Htsget
 


### PR DESCRIPTION
As discussed at last month's meeting, this PR updates _MAINTAINERS.md_ to reflect changes in active personnel:

* Yossi (SAM) and Petr (VCF) are no longer active maintainers;
* Chris's (CRAM) and Kirill's (VCF) ongoing status and availability are open questions, and they might be added to this PR or a followup.

In conjunction with bringing the listed active maintainers up to date, we will review the membership of “Specification authors”, the samtools GH org team that provides write access to hts-specs:

* Yossi and Petr will be removed when this PR is merged;
* @jmthibault79 is a member of the team, IIRC so that there would be an additional person available to push CRAM updates. Is this still applicable?
* It appears that the crypt4gh maintainers (@AlexanderSenf and @daviesrob) were never added to the team, though fortunately Rob has write access by virtue of being a samtools org admin. IMHO we should belatedly add them.