### PR TITLE
Clarify CRAM language on empty files (PR #638).

### DIFF
--- a/CRAMv3.tex
+++ b/CRAMv3.tex
@@ -338,7 +338,7 @@ The overall CRAM file structure is described in this section. Please refer to ot
 sections of this document for more detailed information. 
 
 A CRAM file consists of a fixed length file definition, followed by a CRAM header container,
-then one or more data containers, and finally a special end-of-file container. 
+then zero or more data containers, and finally a special end-of-file container.
 
 \begin{center}
 \begin{tikzpicture}[


### PR DESCRIPTION
Fixes #636 reported by Michael Macias.

I chose to add "optionally" as IMO it reads better than "zero or more".