### PR TITLE
Fixed typo in VCFv4.3 Spec

### DIFF
--- a/VCFv4.3.tex
+++ b/VCFv4.3.tex
@@ -234,7 +234,7 @@ The URL field specifies the location of a fasta file containing breakpoint assem
 \subsubsection{Contig field format}
 \label{sec-contig-field}
 It is recommended for VCF, and required for BCF, that the header includes tags describing the contigs referred to in the file.
-The structured \texttt{contig} field must include the ID attribute and can includes additional optional attributes with
+The structured \texttt{contig} field must include the ID attribute and can include additional optional attributes with
 the following ones reserved:
 \begin{itemize}
   \item length: the length of the sequence


### PR DESCRIPTION
Original text:
> The structured `contig` field must include the ID attribute and can includes additional optional attributes with

Proposed text:
> The structured `contig` field must include the ID attribute and can include additional optional attributes with
