### PR TITLE
CRAM: document process for handling empty blocks.

### DIFF
--- a/CRAMv3.tex
+++ b/CRAMv3.tex
@@ -633,6 +633,12 @@ byte[4] & CRC32 & CRC32 hash value for all preceding bytes in the block\tabularn
 
 * Note on raw method: both compressed and raw sizes must be set to the same value.
 
+Empty blocks may occur in the files.
+Blocks with a raw (uncompressed) size of zero are treated as empty,
+irrespective of their ``method'' byte.  This is equivalent to
+interpreting them as having method zero (raw) and compressed size of
+zero.
+
 \subsection{\textbf{Block content types}}
 
 CRAM has the following block content types:


### PR DESCRIPTION
In theory a zero length block should be RAW format, because all compression codecs add at least 1 byte of meta-data and an empty block of data (post decompression) will never be zero bytes once compressed.

However htsjdk has always been producing blocks claiming to be RANS compressed and zero bytes long.  This is an illegal RANS stream.

For efficiency reasons, if the uncompressed data is labelled as zero bytes it already knows it'll decode to nothing so it doesn't bother trying (treating it as empty & RAW).  So it didn't spot the broken files.

Given the sheer amount of invalid data out there, we instead amend the specification to bless the problem-avoidance strategy used by htslib.

Fixes #680