### PR TITLE
SAM: add a sentence on case-insensitivity of RG PL (PR #684)

### DIFF
--- a/SAMv1.tex
+++ b/SAMv1.tex
@@ -330,7 +330,8 @@ The {\tt TP} field is often omitted, which implies linear.}\\\cline{2-3}
   & {\tt PI} & Predicted median insert size, rounded to the nearest integer.\\\cline{2-3}
   & {\tt PL} & Platform/technology used to produce the reads. \emph{Valid values}:
   {\tt CAPILLARY}, {\tt DNBSEQ} (MGI/BGI), {\tt ELEMENT}, {\tt HELICOS}, {\tt ILLUMINA}, {\tt IONTORRENT}, {\tt LS454}, {\tt ONT} (Oxford Nanopore), {\tt PACBIO} (Pacific Biosciences), {\tt SINGULAR}, {\tt SOLID}, and {\tt ULTIMA}.
-  This field should be omitted when the technology is not in this list (though the {\tt PM} field may still be present in this case) or is unknown.\\\cline{2-3}
+  This field should be omitted when the technology is not in this list (though the {\tt PM} field may still be present in this case) or is unknown.
+  The values should be written as described in uppercase, however due to the existance of public data with lowercase values tools should also accept lowercase when decoding.\\\cline{2-3}
   & {\tt PM} & Platform model. Free-form text providing further details of the platform/technology used.\\\cline{2-3}
   & {\tt PU} & Platform unit (e.g., flowcell-barcode.lane for Illumina or slide for SOLiD). Unique identifier.\\\cline{2-3}
   & {\tt SM} & Sample. Use pool name where a pool is being sequenced.\\\cline{1-3}

--- a/SAMv1.tex
+++ b/SAMv1.tex
@@ -329,9 +329,10 @@ The {\tt TP} field is often omitted, which implies linear.}\\\cline{2-3}
   & {\tt PG} & Programs used for processing the read group.\\\cline{2-3}
   & {\tt PI} & Predicted median insert size, rounded to the nearest integer.\\\cline{2-3}
   & {\tt PL} & Platform/technology used to produce the reads. \emph{Valid values}:
-  {\tt CAPILLARY}, {\tt DNBSEQ} (MGI/BGI), {\tt ELEMENT}, {\tt HELICOS}, {\tt ILLUMINA}, {\tt IONTORRENT}, {\tt LS454}, {\tt ONT} (Oxford Nanopore), {\tt PACBIO} (Pacific Biosciences), {\tt SINGULAR}, {\tt SOLID}, and {\tt ULTIMA}.
-  This field should be omitted when the technology is not in this list (though the {\tt PM} field may still be present in this case) or is unknown.
-  The values should be written as described in uppercase, however due to the existance of public data with lowercase values tools should also accept lowercase when decoding.\\\cline{2-3}
+  {\tt CAPILLARY}, {\tt DNBSEQ} (MGI/BGI), {\tt ELEMENT}, {\tt HELICOS}, {\tt ILLUMINA}, {\tt IONTORRENT}, {\tt LS454}, {\tt ONT} (Oxford Nanopore), {\tt PACBIO} (Pacific Biosciences), {\tt SINGULAR}, {\tt SOLID}, and {\tt ULTIMA}.%
+\footnote{The {\tt PL} value should be written in uppercase exactly as shown in this list of valid values.
+Tools should also accept lowercase when reading the {\tt @RG PL} field, due to the existence of public data files with lowercase {\tt PL} values.}
+  This field should be omitted when the technology is not in this list (though the {\tt PM} field may still be present in this case) or is unknown.\\\cline{2-3}
   & {\tt PM} & Platform model. Free-form text providing further details of the platform/technology used.\\\cline{2-3}
   & {\tt PU} & Platform unit (e.g., flowcell-barcode.lane for Illumina or slide for SOLiD). Unique identifier.\\\cline{2-3}
   & {\tt SM} & Sample. Use pool name where a pool is being sequenced.\\\cline{1-3}

--- a/test/sam/failed/hdr.RG6.sam
+++ b/test/sam/failed/hdr.RG6.sam
@@ -1,1 +1,0 @@
-@RG	ID:1	PL:illumina


### PR DESCRIPTION
This is not changing what is valid / permitted, and indeed this hopefully clarifies it further.  However the practicality of dealing with wide-spread non-compliant data with lowercase PL values is that tools may wish to be lenient and use case-insensitive matching.

Fixes #679