### PR TITLE
fixed typo in Genotype encoding example

### DIFF
--- a/VCFv4.1.tex
+++ b/VCFv4.1.tex
@@ -1111,7 +1111,7 @@ Genotype fields are encoded not by sample as in VCF but rather by field, with a 
 \vspace{0.3cm}
 \begin{tabular}{l l l l}
 FORMAT & NA00001 & NA00002 & NA00003 \\
-GT:GQ:DP & 0/0:48:1 & 0/1:48:8 & 1/1:43:5 \\
+GT:GQ:DP & 0/0:48:1 & 0/1:9:8 & 1/1:43:5 \\
 \end{tabular}
 \vspace{0.3cm}
 

--- a/VCFv4.3.tex
+++ b/VCFv4.3.tex
@@ -1616,7 +1616,7 @@ In BCF2, the following VCF line:
 \vspace{0.3cm}
 \begin{tabular}{l l l l}
 FORMAT & NA00001 & NA00002 & NA00003 \\
-GT:GQ:DP & 0/0:48:1 & 0/1:48:8 & 1/1:43:5 \\
+GT:GQ:DP & 0/0:48:1 & 0/1:9:8 & 1/1:43:5 \\
 \end{tabular}
 \vspace{0.3cm}
 

--- a/VCFv4.4.draft.tex
+++ b/VCFv4.4.draft.tex
@@ -1990,7 +1990,7 @@ In BCF2, the following VCF line:
 \vspace{0.3cm}
 \begin{tabular}{l l l l}
 FORMAT & NA00001 & NA00002 & NA00003 \\
-GT:GQ:DP & 0/0:48:1 & 0/1:48:8 & 1/1:43:5 \\
+GT:GQ:DP & 0/0:48:1 & 0/1:9:8 & 1/1:43:5 \\
 \end{tabular}
 \vspace{0.3cm}
 


### PR DESCRIPTION
Genotype fields in the VCF example don't match the encoding equivalent. Typo was fixed in 2015 for 4.2 only (commit: https://github.com/samtools/hts-specs/commit/b6abaee0bab868437df7e4b78900d9aa18a90e3d), so this PR makes the same changes for 4.1, 4.3, and 4.4. 

Note that this only updates the .tex, not the PDFs. 