### PR TITLE
Remove use of lowercase hex in SAM aux "H" tag in test data

### DIFF
--- a/test/sam/passed/aux.pass-H.sam
+++ b/test/sam/passed/aux.pass-H.sam
@@ -1,4 +1,4 @@
 @CO	Validation of AUX
 @CO	Type H
-h1	4	*	0	0	*	*	0	0	CAT	QQQ	H0:H:deadbeef	H1:H:DEADBEEF	H2:H:0123456789ABCDEF
+h1	4	*	0	0	*	*	0	0	CAT	QQQ	H1:H:DEADBEEF	H2:H:0123456789ABCDEF
 h1	4	*	0	0	*	*	0	0	CAT	QQQ	H0:H:	ZZ:Z:empty	H1:H:


### PR DESCRIPTION
The spec requires uppercase only, and we already have a failed sam/failed/aux.fail-H2.sam as a validation that lowercase is incorrect.

Fixes #693