### PR TITLE
[DRAFT] Mark /github/workspace as a safe directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ new/CRAMv2.1.ver new/CRAMv3.ver: img/CRAMFileFormat2-1-fig001.png img/CRAMFileFo
 new/VCFv4.1.ver new/VCFv4.2.ver new/VCFv4.3.ver new/VCFv4.4.ver: img/all_orientations-400x296.png img/derivation-400x267.png img/erosion-400x211.png img/inserted_contig-400x247.png img/inserted_sequence-400x189.png img/inversion-400x95.png img/microhomology-400x248.png img/multiple_mates-400x280.png img/phasing-400x259.png img/reciprocal_rearrangement-400x192.png img/telomere-400x251.png
 
 new/%.ver: %.tex | new
+	[ "x`pwd`" = "x/github/workspace" ] && git config --global --add safe.directory `pwd`
 	scripts/genversion.sh $^ > $@
 
 new:

--- a/SAMv1.tex
+++ b/SAMv1.tex
@@ -11,6 +11,8 @@
 \usepackage[calc]{picture}
 \usepackage{tikz}
 
+% Irrelevant change to force rebuild
+
 \newlength{\bytewidth}
 \newlength{\bytetotalheight}
 \newlength{\bytedepth}


### PR DESCRIPTION
Our latex CI has been failing on a lot of the tex specs with e.g.:

```
scripts/genversion.sh CRAMv2.1.tex img/CRAMFileFormat2-1-fig001.png img/CRAMFileFormat2-1-fig002.png img/CRAMFileFormat2-1-fig003.png img/CRAMFileFormat2-1-fig004.png img/CRAMFileFormat2-1-fig005.png img/CRAMFileFormat2-1-fig006.png img/CRAMFileFormat2-1-fig007.png > new/CRAMv2.1.ver
fatal: detected dubious ownership in repository at '/github/workspace'
To add an exception for this directory, call:

	git config --global --add safe.directory /github/workspace
fatal: detected dubious ownership in repository at '/github/workspace'
To add an exception for this directory, call:
```

This appears to be some new security measure, but not obviously in git itself as I've tried the very latest release locally and it's fine.  I'm assuming this is some github specific extension which has been applied.

In theory we can add

```
  set-safe-directory:
    default: true
```

to the inputs: part of texlive/action.yml, but that doesn't work.  I also tried the more explicit:

```
set-safe-directory: '/github/workspace'
```

in the actions/checkout@v3 part of pr-pdfs.yaml, but that also got ignored.

So instead this is a nuclear option of just putting the git command verbatim into the Makefile and guarding it with a pathname so it only runs from the CI environment.  There must be a better way!

I'll likely keep force pushing this if it fails. :)