### PR TITLE
Document the ambiguity of 1-base long seq with QUAL *

### DIFF
--- a/SAMv1.tex
+++ b/SAMv1.tex
@@ -636,13 +636,14 @@ Each bit is explained in the following table:
 \item {\sf QUAL}: ASCII of base QUALity plus 33 (same as the quality
   string in the Sanger FASTQ format). A base quality is the phred-scaled
   base error probability which equals $-10\log_{10}\Pr\{\mbox{base is
-    wrong}\}$.
-  This field can be a `*' when quality is not stored.\footnote{Note an
-  ambiguity exists for the unlikely case of a non-`*' sequence of length 1
-  with base quality 9 (ASCII `*').  Given the ambiguity, the quality
-  should always deemed to be unavailable in this scenario.}
-  If not a `*', {\sf SEQ} must not be a `*' and the length of the quality
-  string ought to equal the length of {\sf SEQ}.
+  wrong}\}$. This field can be a `*' when quality is not stored.\footnote{In
+  the unlikely case in which {\sf SEQ} is of length~1 and {\sf QUAL} is `*',
+  {\sf QUAL} should be interpreted as quality not stored. Tools should avoid
+  writing a solitary base quality 9 (ASCII `{\tt *}') to SAM, BAM, or CRAM files
+  for alignment lines where {\sf SEQ} is of length~1, instead adjusting the
+  base quality to 10 (ASCII `{\tt +}') to avoid this potential ambiguity.} If
+  not a `*', {\sf SEQ} must not be a `*' and the length of the quality string
+  ought to equal the length of {\sf SEQ}.
 \end{enumerate}
 
 \subsection{The alignment section: optional fields}\label{sec:alnaux}

--- a/SAMv1.tex
+++ b/SAMv1.tex
@@ -636,9 +636,13 @@ Each bit is explained in the following table:
 \item {\sf QUAL}: ASCII of base QUALity plus 33 (same as the quality
   string in the Sanger FASTQ format). A base quality is the phred-scaled
   base error probability which equals $-10\log_{10}\Pr\{\mbox{base is
-    wrong}\}$. This field can be a `*' when quality is not stored. If
-  not a `*', {\sf SEQ} must not be a `*' and the length of the quality string
-  ought to equal the length of {\sf SEQ}.
+    wrong}\}$.
+  This field can be a `*' when quality is not stored.\footnote{Note an
+  ambiguity exists for the unlikely case of a non-`*' sequence of length 1
+  with base quality 9 (ASCII `*').  Given the ambiguity, the quality
+  should always deemed to be unavailable in this scenario.}
+  If not a `*', {\sf SEQ} must not be a `*' and the length of the quality
+  string ought to equal the length of {\sf SEQ}.
 \end{enumerate}
 
 \subsection{The alignment section: optional fields}\label{sec:alnaux}


### PR DESCRIPTION
This is an extreme edge case likely to never occur, but nevertheless tool implementors still need to know how to handle it.  Given it *may* be QUAL 9 or it *may* be QUAL "unknown", we treat it as always unknown.

Fixes #715