### PR TITLE
Recommend 1bp SEQ with QUAL="*" as quality-unavailable.

### DIFF
--- a/SAMv1.tex
+++ b/SAMv1.tex
@@ -75,7 +75,7 @@ SAM file contents are 7-bit US-ASCII, except for certain field values as individ
 Alternatively and equivalently, SAM files are encoded in UTF-8 but non-ASCII characters are permitted only within certain field values as explicitly specified in the descriptions of those fields.%
 \footnote{Hence in particular SAM files must not begin with a byte order mark~(BOM) and lines of text are delimited by ASCII line terminator characters only.
 % Unicode identifies VT and FF as line break characters as well, but no one uses them in SAM.
-In addition to the local platform's text file line termination conventions, implementations may wish to support \textsc{lf} and \textsc{cr\>lf} for interoperability with other platforms.}
+In addition to the local platform's text file line termination conventions, implementations may wish to support \textsc{lf} and \textsc{cr\,lf} for interoperability with other platforms.}
 
 Where it makes a difference, SAM file contents should be read and written using the POSIX\,/\,C locale.
 For example, floating-point values in SAM always use `{\tt .}' for the decimal-point character.

--- a/SAMv1.tex
+++ b/SAMv1.tex
@@ -651,6 +651,10 @@ Each bit is explained in the following table:
     wrong}\}$. This field can be a `*' when quality is not stored. If
   not a `*', {\sf SEQ} must not be a `*' and the length of the quality string
   ought to equal the length of {\sf SEQ}.
+  \footnote{There is a small ambiguity with a sequence exactly one
+    base-pair long having quality 9.  This is ASCII `*' so it could be
+    interpreted as either QUAL 9 or as quality unavailable.  Given
+    this ambiguity, we recommend interpreting it as unavailable.}
 \end{enumerate}
 
 \subsection{The alignment section: optional fields}\label{sec:alnaux}


### PR DESCRIPTION
The change is simply a footnote indicating the presence of the ambiguity and a mild recommendation, however it's not likely to make any practical difference in real-world data where even if 1bp reads exist their quality values aren't likely to be a deciding factor over their validity.

Also in attempting to build the SAM spec my latex blew up.  This turns out to be due to #670 which added use of `\>` for non-breaking space.  Our systems here are pretty old, and latex couldn't cope with that.  However in the interests of keeping the spec as easy to build as possible, I did a trivial replacement in its own commit.