### PR TITLE
Add SAM recommendation of MAPQ=0 for unmapped reads

### DIFF
--- a/SAMv1.tex
+++ b/SAMv1.tex
@@ -737,6 +737,7 @@ specific software package for it to function properly.
   \item Unmapped reads should be stored in the orientation in which they came
     off the sequencing machine and have their {\sf reverse} flag bit~(0x10)
     correspondingly unset.
+  \item Unmapped reads should have mapping quality zero.
   \end{enumerate}
 \item Multiple mapping
   \begin{enumerate}[label=\arabic*]

--- a/SAMv1.tex
+++ b/SAMv1.tex
@@ -737,7 +737,20 @@ specific software package for it to function properly.
   \item Unmapped reads should be stored in the orientation in which they came
     off the sequencing machine and have their {\sf reverse} flag bit~(0x10)
     correspondingly unset.
-  \item Unmapped reads should have mapping quality zero.
+  \item Fields stated to have no assumptions on their content if {\sf FLAG}
+      bit 0x4 is set (unmapped) should have values `{\tt *}' or `{\tt 0}' as
+      appropriate.
+      \footnote{This is desirable as CRAM will not store some or all of these
+        fields for unmapped data, so round-trips should yield these default
+        values for maximum compatibility.}
+
+      Specifically this includes {\sf RNAME} (`{\tt *}', but see caveat),
+      {\sf POS} (`{\tt 0}', see caveat), {\sf CIGAR} (`{\tt *}'),
+      {\sf MAPQ} ('{\tt 0}') and {\sf FLAG} bits 0x2, 0x100 and 0x800
+      (all unset).
+
+      One caveat to this is with paired sequencing protocols where one record
+      is aligned and one unaligned within a pair.  See item 1 above.
   \end{enumerate}
 \item Multiple mapping
   \begin{enumerate}[label=\arabic*]


### PR DESCRIPTION
We already have a recommendation that MAPQ of 255 should not be used. Expand on this to recommend zero is used when unmapped.

This is purely a recommendation, made for maximum compatibility, and not a specification requirement.

Fixes #727