### PR TITLE
Add subtitles noting VCFv4.[1-4].pdf have been superseded by later versions

### DIFF
--- a/VCFv4.1.tex
+++ b/VCFv4.1.tex
@@ -9,7 +9,7 @@
 \input{VCFv4.1.ver}
 \title{The Variant Call Format (VCF) Version 4.1 Specification
 \normalsize\\[2ex]
-(Superseded by the \href{http://samtools.github.io/hts-specs/VCFv4.2.pdf}{VCF v4.2} and \href{http://samtools.github.io/hts-specs/VCFv4.3.pdf}{v4.3} specifications)}
+(Superseded by the \href{http://samtools.github.io/hts-specs/VCFv4.2.pdf}{VCF v4.2} through \href{http://samtools.github.io/hts-specs/VCFv4.5.pdf}{v4.5} specifications)}
 \date{\headdate}
 \maketitle
 \begin{quote}\small

--- a/VCFv4.2.tex
+++ b/VCFv4.2.tex
@@ -9,7 +9,7 @@
 \input{VCFv4.2.ver}
 \title{The Variant Call Format (VCF) Version 4.2 Specification
 \normalsize\\[2ex]
-(Superseded by the \href{http://samtools.github.io/hts-specs/VCFv4.3.pdf}{VCF v4.3} specification introduced in October 2015)}
+(Superseded by the \href{http://samtools.github.io/hts-specs/VCFv4.3.pdf}{VCF v4.3} through \href{http://samtools.github.io/hts-specs/VCFv4.5.pdf}{v4.5} specifications)}
 \date{\headdate}
 \maketitle
 \begin{quote}\small

--- a/VCFv4.3.tex
+++ b/VCFv4.3.tex
@@ -18,7 +18,9 @@
 
 \begin{document}
 \input{VCFv4.3.ver}
-\title{The Variant Call Format Specification \\ \vspace{0.5em} \large VCFv4.3 and BCFv2.2}
+\title{The Variant Call Format Specification \\ \vspace{0.5em} \large VCFv4.3 and BCFv2.2
+\normalsize\\[2ex]
+(Superseded by the \href{http://samtools.github.io/hts-specs/VCFv4.4.pdf}{VCF v4.4} and \href{http://samtools.github.io/hts-specs/VCFv4.5.pdf}{v4.5} specifications)}
 \date{\headdate}
 \maketitle
 \begin{quote}\small

--- a/VCFv4.4.tex
+++ b/VCFv4.4.tex
@@ -18,7 +18,9 @@
 
 \begin{document}
 \input{VCFv4.4.ver}
-\title{The Variant Call Format Specification \\ \vspace{0.5em} \large VCFv4.4 and BCFv2.2}
+\title{The Variant Call Format Specification \\ \vspace{0.5em} \large VCFv4.4 and BCFv2.2
+\normalsize\\[2ex]
+(Superseded by the \href{http://samtools.github.io/hts-specs/VCFv4.5.pdf}{VCF v4.5} specification)}
 \date{\headdate}
 \maketitle
 \begin{quote}\small


### PR DESCRIPTION
With the recent [promulgation of VCF v4.5](https://twitter.com/GA4GH/status/1820915065114992984), add “superseded by…” subtitles to the v4.3 and v4.4 specs. Cf PR #542.

Adjust the v4.1 and v4.2 subtitles to account for newer specs. The previous v4.2 noted “[new spec] introduced in October 2015” because the note was added years after the fact; we don't need to emphasis that this time around as we're contemporaneous.