### PR TITLE
Explicitly permit eg N+m in MM tag (PR#799)

### DIFF
--- a/SAMtags.tex
+++ b/SAMtags.tex
@@ -532,6 +532,7 @@ For example `{\tt C+76792,57;}' is the same as `{\tt C+h,57;}'.
 
 An unmodified base of `{\tt N}' means count any base in {\sf SEQ}, not only those of `{\tt N}'.
 Thus `{\tt N+n,100;}' means the 101st base is Xanthosine (n), irrespective of the sequence composition.
+A fundamental base of `{\tt N}' may also be used with a base-specific modification code to force the counting to be applied per base rather than per base-type.
 
 The standard code types and their associated ChEBI values are listed
 below, taken from Viner {\it et al.}%
@@ -567,6 +568,7 @@ G & G &       & Ambiguity code; any G mod & \\
 \hline
 N & n & Xao   & Xanthosine              & 18107 \\
 N & N &       & Ambiguity code; any mod & \\
+N & any &     & Mod applied to any base & \\
 \end{tabular}
 \end{center}
 


### PR DESCRIPTION
The text already states that an unmodified base of N means we count any base type, but base N code N in the table is a little misleading as to the intention.  It was intended to mean any unspecified modification, in the same way C+C is any unspecified C mod, but in this case it's against all bases rather than a specific base type.

However that doesn't solve the issue of whether we can record specific mods against any "fundamental" source base.  Clarified this by adding an extra line to the table and some text.  (However note this doesn't necessarily imply downstream processing tools will not do any compatibility assessment and reject N+m when the SEQ base is a T.)

Fixes #785