### PR TITLE
Movement of refget from hts-specs to GA4GH refget

### DIFF
--- a/refget.md
+++ b/refget.md
@@ -4,6 +4,8 @@ title: refget protocol
 suppress_footer: true
 ---
 
+<strong>Refget's specification is no longer hosted here and has moved to the central <a href="https://ga4gh.github.io/refget/sequences/">GA4GH Refget repository</a>. Please update your bookmarks</strong>
+
 # Refget API Specification v2.0.0
 {:.no_toc}
 


### PR DESCRIPTION
As part of approval for refget sequence collections, we have created a new repository for refget under the [GA4GH GitHub space](https://github.com/ga4gh/refget). This PR denotes the current supported location is in the new location but retains the v2.0.0 spec here for reference.