### PR TITLE
Fix CRAM record counter to be 0 based.

### DIFF
--- a/CRAMv3.tex
+++ b/CRAMv3.tex
@@ -573,7 +573,7 @@ itf8 & alignment span & the length of the alignment\tabularnewline
 \hline
 itf8 & number of records & number of records in the container\tabularnewline
 \hline
-ltf8 & record counter & 1-based sequential index of records in the file/stream.\tabularnewline
+ltf8 & record counter & 0-based sequential index of records in the file/stream.\tabularnewline
 \hline
 ltf8 & bases & number of read bases\tabularnewline
 \hline
@@ -946,7 +946,7 @@ itf8 & alignment span & the length of the alignment\tabularnewline
 \hline
 itf8 & number of records & the number of records in the slice\tabularnewline
 \hline
-ltf8 & record counter & 1-based sequential index of records in the file/stream\tabularnewline
+ltf8 & record counter & 0-based sequential index of records in the file/stream\tabularnewline
 \hline
 itf8 & number of blocks & the number of blocks in the slice\tabularnewline
 \hline


### PR DESCRIPTION
This matches io_lib, htslib and htsjdk's implementations, none of which adhered to the documented 1-based coordinates.

Fixes #807