### PR TITLE
Clarify ambiguity in ITF-8 format

### DIFF
--- a/CRAMv3.tex
+++ b/CRAMv3.tex
@@ -207,8 +207,10 @@ encoding and therefore this encoding is called ITF-8 (Integer Transformation For
 - 8 bit). 
 
 The most significant bits of the first byte have special meaning and are called 
-`prefix'. These are 0 to 4 true bits followed by a 0. The number of 1's denote 
-the number of bytes to follow. To accommodate 32 bits such representation requires 
+`prefix'. These are 0 to 3 true bits followed by a 0 or 4 true bits. 
+The number of 1's denote  the number of bytes to follow. So 0 for no bytes, 10 
+for 1 byte, 110 for two bytes, 1110 for three bytes and 1111 for four bytes.
+To accommodate 32 bits such representation requires 
 5 bytes with only 4 lower bits used in the last byte 5.
 
 \item[LTF-8 long (ltf8)]\ \newline


### PR DESCRIPTION
The original states: 

> These are 0 to 4 true bits followed by a 0.

This is untrue, because when there are 4 true bits, these are not followed by a 0. If they had been followed by a zero the following statement would be untrue.

> To accommodate 32 bits such representation requires 5 bytes with only 4 lower bits used in the last byte 5.

That should have been 5 lower bits. So there is an ambiguity here. Are the 4 true bits not followed by a 0 and the last byte contains 4 lower bits, or are they followed by a 0 and the last byte contains 5 lower bits?

I checked the htslib implementation and the former is true. So I corrected the sentence. To further disambiguate all the bit patterns are written down to make sure there is no room for doubt. 