### PR TITLE
minor corrections in BCF2.2 GT example table

### DIFF
--- a/VCFv4.3.tex
+++ b/VCFv4.3.tex
@@ -1880,8 +1880,8 @@ $0\mid1$ & $(1 + 1) << 1 \mid 1$ = 0x05 preceded by the standard first byte valu
 ./. & where both alleles are missing & 0x00 00 \\ \hline
 0 & as a haploid it is represented by a single byte & 0x02 \\ \hline
 1 & as a haploid it is represented by a single byte & 0x04 \\ \hline
-0/1/2 & is tetraploid, with alleles & 0x02 04 06 \\ \hline
-$0/1\mid2$ & is tetraploid with a single phased allele & 0x02 04 07 \\ \hline
+0/1/2 & is triploid, with alleles & 0x02 04 06 \\ \hline
+$0/1\mid2$ & is triploid with a single phased allele & 0x02 04 07 \\ \hline
 0 and 0/1 & pad out the final allele for the haploid individual & 0x02 81 02 04\\ \hline
 \end{tabular}
 \normalsize

--- a/VCFv4.4.tex
+++ b/VCFv4.4.tex
@@ -2309,9 +2309,9 @@ $0\mid1$ & $(1 + 1) << 1 \mid 1$ = 0x05 preceded by the phased first byte value 
 ./. & where both alleles are missing & 0x00 00 \\ \hline
 0 & as an implicitly phased haploid it is represented by a single byte & 0x03 \\ \hline
 1 & as an implicitly phased haploid it is represented by a single byte & 0x05 \\ \hline
-0/1/2 & is tetraploid, with alleles & 0x02 04 06 \\ \hline
-$0/1\mid2$ & is tetraploid with a single phased allele & 0x02 04 07 \\ \hline
-0 and 0/1 & pad out the final allele for the haploid individual & 0x02 81 02 04\\ \hline
+0/1/2 & is triploid, with alleles & 0x02 04 06 \\ \hline
+$0/1\mid2$ & is triploid with a single phased allele & 0x02 04 07 \\ \hline
+0 and 0/1 & pad out the final allele for the haploid individual & 0x03 81 02 04\\ \hline
 \end{tabular}
 \normalsize
 

--- a/VCFv4.5.tex
+++ b/VCFv4.5.tex
@@ -2477,9 +2477,9 @@ $0\mid1$ & $(1 + 1) << 1 \mid 1$ = 0x05 preceded by the phased first byte value 
 ./. & where both alleles are missing & 0x00 00 \\ \hline
 0 & as an implicitly phased haploid it is represented by a single byte & 0x03 \\ \hline
 1 & as an implicitly phased haploid it is represented by a single byte & 0x05 \\ \hline
-0/1/2 & is tetraploid, with alleles & 0x02 04 06 \\ \hline
-$0/1\mid2$ & is tetraploid with a single phased allele & 0x02 04 07 \\ \hline
-0 and 0/1 & pad out the final allele for the haploid individual & 0x02 81 02 04\\ \hline
+0/1/2 & is triploid, with alleles & 0x02 04 06 \\ \hline
+$0/1\mid2$ & is triploid with a single phased allele & 0x02 04 07 \\ \hline
+0 and 0/1 & pad out the final allele for the haploid individual & 0x03 81 02 04\\ \hline
 \end{tabular}
 \normalsize
 


### PR DESCRIPTION
BCF 2.2 GT example (section 6.3.3) shows pading with end_of_vector and the value seems incorrect.
0 and 0/1 with values 0x02 81 02 04 updated as **0x03** 81 02 04.

In same table, tetraploid is updated as triploid.