### PR TITLE
Fix BGZF block size to be 64 kilobyte

### DIFF
--- a/SAMv1.tex
+++ b/SAMv1.tex
@@ -921,7 +921,7 @@ use of {\sf GZIPInputStream} on a BGZF file will not work due to this
 bug.}
 
 A BGZF file is a series of concatenated BGZF blocks, each no larger
-than~64Kb before or after compression. Each BGZF block
+than 64\,KiB both before and after compression. Each BGZF block
 is itself a spec-compliant gzip archive which contains an ``extra field''
 in the format described in RFC1952. The gzip file format allows the
 inclusion of application-specific extra fields and these are ignored by


### PR DESCRIPTION
This commit fixes two small issues.

- The lowercase `b` might be interpreted as `bit`.
- Be slightly more precise that the 64KB limit applies to compressed and uncompressed data both.