### PR TITLE
Minor kb and gigabytes notation improvements for all VCF specs

### DIFF
--- a/VCFv4.1.tex
+++ b/VCFv4.1.tex
@@ -517,7 +517,7 @@ The example shows in order:
   \item An imprecise deletion of approximately 105 bp.
   \item An imprecise deletion of an ALU element relative to the reference.
   \item An imprecise insertion of an L1 element relative to the reference.
-  \item An imprecise duplication of approximately 21Kb. The sample genotype is copy number 3 (one extra copy of the duplicated sequence).
+  \item An imprecise duplication of approximately 21kb. The sample genotype is copy number 3 (one extra copy of the duplicated sequence).
   \item An imprecise tandem duplication of 76bp. The sample genotype is copy number 5 (but the two haplotypes are not known).
 \end{enumerate}
 

--- a/VCFv4.1.tex
+++ b/VCFv4.1.tex
@@ -957,8 +957,8 @@ Haplotype quality & 30 & 40 & 40 \\
 VCF is very expressive, accommodates multiple samples, and is widely used
 in the community.  Its biggest drawback is that it is big and slow.
 Files are text and therefore require a lot of space on disk.  A normal batch
-of \~100~exomes is a few GB, but large-scale VCFs with thousands of exome
-samples quickly become hundreds of GBs.  Because the file is text, it is
+of \~100~exomes is a few gigabytes, but large-scale VCFs with thousands of exome
+samples quickly become hundreds of gigabytes.  Because the file is text, it is
 extremely slow to parse.
 
 Overall, the idea behind is BCF2 is simple.  BCF2 is a binary, compressed

--- a/VCFv4.2.tex
+++ b/VCFv4.2.tex
@@ -974,8 +974,8 @@ Haplotype quality & 30 & 40 & 40 \\
 VCF is very expressive, accommodates multiple samples, and is widely used
 in the community.  Its biggest drawback is that it is big and slow.
 Files are text and therefore require a lot of space on disk.  A normal batch
-of \~100~exomes is a few GB, but large-scale VCFs with thousands of exome
-samples quickly become hundreds of GBs.  Because the file is text, it is
+of \~100~exomes is a few gigabytes, but large-scale VCFs with thousands of exome
+samples quickly become hundreds of gigabytes.  Because the file is text, it is
 extremely slow to parse.
 
 Overall, the idea behind is BCF2 is simple.  BCF2 is a binary, compressed

--- a/VCFv4.2.tex
+++ b/VCFv4.2.tex
@@ -534,7 +534,7 @@ The example shows in order:
   \item An imprecise deletion of approximately 205 bp.
   \item An imprecise deletion of an ALU element relative to the reference.
   \item An imprecise insertion of an L1 element relative to the reference.
-  \item An imprecise duplication of approximately 21Kb. The sample genotype is copy number 3 (one extra copy of the duplicated sequence).
+  \item An imprecise duplication of approximately 21kb. The sample genotype is copy number 3 (one extra copy of the duplicated sequence).
   \item An imprecise tandem duplication of 76bp. The sample genotype is copy number 5 (but the two haplotypes are not known).
 \end{enumerate}
 

--- a/VCFv4.3.tex
+++ b/VCFv4.3.tex
@@ -1454,7 +1454,7 @@ Example records are given below:
 VCF is very expressive, accommodates multiple samples, and is widely used in the community.
 Its biggest drawback is that it is big and slow.
 Files are text and therefore require a lot of space on disk.
-A normal batch of a hundred exomes is a few GB, but large-scale VCFs with thousands of exome samples quickly become hundreds of GBs.
+A normal batch of a hundred exomes is a few gigabytes, but large-scale VCFs with thousands of exome samples quickly become hundreds of gigabytes.
 Because the file is text, it is extremely slow to parse.
 
 Overall, the idea behind is BCF2 is simple.

--- a/VCFv4.3.tex
+++ b/VCFv4.3.tex
@@ -874,7 +874,7 @@ The following page contains examples of structural variants encoded in VCF, show
   \item An imprecise deletion of approximately 205 bp.
   \item An imprecise deletion of an ALU element relative to the reference.
   \item An imprecise insertion of an L1 element relative to the reference.
-  \item An imprecise duplication of approximately 21Kb. The sample genotype is copy number 3 (one extra copy of the duplicated sequence).
+  \item An imprecise duplication of approximately 21kb. The sample genotype is copy number 3 (one extra copy of the duplicated sequence).
   \item An imprecise tandem duplication of 76bp. The sample genotype is copy number 5 (but the two haplotypes are not known).
 \end{enumerate}
 

--- a/VCFv4.4.tex
+++ b/VCFv4.4.tex
@@ -1882,7 +1882,7 @@ chr1 1000000 . T <CNV:TR> . . END=20000;SVLEN=20000;CN=1.25;RUL=10000;RUC=5;RUB=
 VCF is very expressive, accommodates multiple samples, and is widely used in the community.
 Its biggest drawback is that it is big and slow.
 Files are text and therefore require a lot of space on disk.
-A normal batch of a hundred exomes is a few GB, but large-scale VCFs with thousands of exome samples quickly become hundreds of GBs.
+A normal batch of a hundred exomes is a few gigabytes, but large-scale VCFs with thousands of exome samples quickly become hundreds of gigabytes.
 Because the file is text, it is extremely slow to parse.
 
 Overall, the idea behind is BCF2 is simple.

--- a/VCFv4.5.tex
+++ b/VCFv4.5.tex
@@ -2050,7 +2050,7 @@ chr1 1000000 . T <CNV:TR> . . SVLEN=20000;CN=1.25;RUL=10000;RUC=5;RUB=10000,1050
 VCF is very expressive, accommodates multiple samples, and is widely used in the community.
 Its biggest drawback is that it is big and slow.
 Files are text and therefore require a lot of space on disk.
-A normal batch of a hundred exomes is a few GB, but large-scale VCFs with thousands of exome samples quickly become hundreds of GBs.
+A normal batch of a hundred exomes is a few gigabytes, but large-scale VCFs with thousands of exome samples quickly become hundreds of gigabytes.
 Because the file is text, it is extremely slow to parse.
 
 Overall, the idea behind is BCF2 is simple.


### PR DESCRIPTION
VCF parts split out from PR #839 — see the conversation there:

* _VCFv4.[123].tex_ each use `Kb` once which should be corrected to `kb` as it's referring to (decimal) kilobases.
* _VCFv4.[1-5].tex_ also use `GB`, which could be changed to `GiB` or just spelt out as gigabytes as it is in informal prose.