### PR TITLE
Relax MM tag regexp

### DIFF
--- a/SAMtags.tex
+++ b/SAMtags.tex
@@ -488,7 +488,7 @@ Each modified base prediction listed also has a quality value associated with it
 Given the unmodified base already has a phred likelihood, this base modification quality should be interpreted as the likelihood of this modification being correct given an assumption the original call is correct.
 
 \begin{description}
-\item[MM:Z:\tagregex{([ACGTUN][-+]([a-z]+|[0-9]+)[.?]?(,[0-9]+)*;)*}]
+\item[MM:Z:\tagregex{([ACGTUN][-+]([A-Za-z]+|[0-9]+)[.?]?(,[0-9]+)*;)*}]
 \hfill\\
 The first character is the unmodified ``fundamental'' base as reported
 by the sequencing instrument for the top strand.


### PR DESCRIPTION
We permit e.g. "C" as a base modification code to mean "any unspecified C modification".  This means C+C,1,2,3 or even C+mhC,1,2,3 to show 5mC and 5hmC specifically, and a joint "any C including m, h plus other unspecified ones".

Fixes #854